### PR TITLE
refactor: Use capability-based requirements for skills

### DIFF
--- a/.claude/skills/podcast-profile/SKILL.md
+++ b/.claude/skills/podcast-profile/SKILL.md
@@ -4,7 +4,8 @@ description: >
   Podcast generation patterns learned from training data.
   Includes segment structures, style profiles, and quality thresholds.
 context: fork
-agent: codebase-scout
+requires:
+  tools: [Read, Glob, Grep]
 ---
 
 # Podcast Profile Skill

--- a/.claude/skills/provider-integration/SKILL.md
+++ b/.claude/skills/provider-integration/SKILL.md
@@ -4,7 +4,9 @@ description: >
   Guidelines for integrating video and audio generation providers.
   Includes API patterns, rate limits, and provider-specific gotchas.
 context: fork
-agent: spec-implementer
+requires:
+  tools: [Read, Edit, Write, Glob, Grep, Bash]
+  model: sonnet
 ---
 
 # Provider Integration Skill

--- a/.claude/skills/video-production/SKILL.md
+++ b/.claude/skills/video-production/SKILL.md
@@ -4,7 +4,8 @@ description: >
   Video production pipeline patterns including rendering,
   encoding, and quality validation. Covers FFmpeg and tier specs.
 context: fork
-agent: spec-implementer
+requires:
+  tools: [Read, Bash, Glob, Grep]
 ---
 
 # Video Production Skill


### PR DESCRIPTION
Replace agent-specific binding with declarative requirements:
- `requires.tools`: List of tools the skill needs
- `requires.model`: Minimum model tier (optional)

This allows any agent with matching capabilities to execute the skill, making the system more flexible as agents evolve.

https://claude.ai/code/session_01HZy8TMTYJwR1AS5mKnwxDt