### PR TITLE
Add cloud session auto-setup and active specs documentation

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "startup",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/scripts/install_pkgs.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -114,12 +114,19 @@ Storage: `artifacts/memory.json` (local) or Bedrock AgentCore (production)
 4. **Checkpointing** - Provider onboarding has resume capability (`--resume`)
 5. **Parallelism consideration** - For narrative consistency, video scenes often need sequential generation with keyframe passing
 
+## Active Specs (read before implementing)
+
+- [AUDIO_VIDEO_ORCHESTRATION_PATCH.md](docs/specs/AUDIO_VIDEO_ORCHESTRATION_PATCH.md) — Wire audio into EDL + mixing
+- [PODCAST_TRAINING_PIPELINE.md](docs/specs/PODCAST_TRAINING_PIPELINE.md) — ML-style podcast quality training
+- [MULTI_PROVIDER_ORCHESTRATION.md](docs/specs/MULTI_PROVIDER_ORCHESTRATION.md) — Provider system architecture
+
 ## Working Style
 
 - Use the codebase-scout subagent to find files before modifying them
 - Use the test-runner subagent after making changes
 - Read only the specific section of a spec needed for the current task
 - Do not read entire files when Grep can find the relevant lines
+- After implementing, always run: `python -m py_compile <file>` then `pytest`
 
 ## Current State (Jan 2026)
 

--- a/scripts/install_pkgs.sh
+++ b/scripts/install_pkgs.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+# Auto-install project in cloud sessions (CCW / & background tasks)
+# This runs via SessionStart hook when CLAUDE_CODE_REMOTE=true
+
+set -e
+
+# Skip if not in a cloud session
+if [ "$CLAUDE_CODE_REMOTE" != "true" ]; then
+  echo "[install_pkgs] Local session detected, skipping remote install."
+  exit 0
+fi
+
+echo "[install_pkgs] Cloud session detected. Installing project..."
+
+# Install in development mode
+if [ -f "pyproject.toml" ] || [ -f "setup.py" ]; then
+  pip install -e ".[dev]" 2>&1 | tail -5
+  echo "[install_pkgs] Project installed in dev mode."
+elif [ -f "requirements.txt" ]; then
+  pip install -r requirements.txt 2>&1 | tail -5
+  echo "[install_pkgs] Requirements installed."
+else
+  echo "[install_pkgs] No install target found (no pyproject.toml, setup.py, or requirements.txt)"
+fi
+
+# Verify key imports work
+python -c "import click; print('[install_pkgs] click OK')" 2>/dev/null || true
+python -c "import pytest; print('[install_pkgs] pytest OK')" 2>/dev/null || true
+
+echo "[install_pkgs] Setup complete."


### PR DESCRIPTION
## Summary
This PR adds automatic project installation for cloud sessions and updates documentation to reference active implementation specs.

## Key Changes

- **Cloud session auto-setup**: Added `.claude/settings.json` with SessionStart hook that triggers `scripts/install_pkgs.sh` when `CLAUDE_CODE_REMOTE=true`
- **Installation script**: Created `scripts/install_pkgs.sh` to automatically install the project in dev mode during cloud sessions, with fallback support for `requirements.txt` and verification of key dependencies
- **Documentation updates**: 
  - Added "Active Specs" section to CLAUDE.md referencing three key implementation specs (audio/video orchestration, podcast training pipeline, multi-provider orchestration)
  - Added testing reminder to working style guidelines (`py_compile` + `pytest`)

## Implementation Details

The installation script:
- Only runs in cloud sessions (checks `CLAUDE_CODE_REMOTE` environment variable)
- Supports multiple project configurations (`pyproject.toml`, `setup.py`, or `requirements.txt`)
- Verifies critical imports (click, pytest) with graceful fallback
- Outputs minimal logging (tail -5) to keep session logs clean

This enables seamless project setup in remote Claude sessions without manual intervention.

https://claude.ai/code/session_01UrHiS7fYowktg9YgSC3NBJ