### PR TITLE
docs: comprehensive CLI reference

### DIFF
--- a/docs/cli/README.md
+++ b/docs/cli/README.md
@@ -1,0 +1,219 @@
+# Claude Studio Producer - CLI Reference
+
+Claude Studio Producer provides a comprehensive command-line interface for AI video production with multi-agent orchestration.
+
+## Quick Start
+
+```bash
+# Quick demo with mock providers
+claude-studio produce -c "Logo reveal for TechCorp" -d 5 --mock
+
+# Live production with Luma
+claude-studio produce -c "Product demo" -b 15 -d 30 --live -p luma
+
+# Generate video from transcript
+claude-studio produce-video --script script.txt --live --kb my-project
+```
+
+## Command Overview
+
+| Command | Purpose | Key Options |
+|---------|---------|-------------|
+| [produce](produce.md) | Run full video production pipeline | `--concept`, `--budget`, `--live`, `--provider` |
+| [produce-video](produce-video.md) | Generate explainer videos from scripts | `--from-training`, `--script`, `--live`, `--kb-project` |
+| [assemble](assemble.md) | Create rough cut video from production assets | `--output`, `--skip-existing` |
+| [assets](assets.md) | Asset tracking and approval workflow | `list`, `approve`, `reject`, `build` |
+| [resume](resume.md) | Resume interrupted productions | `--live`, `--skip-qa`, `--skip-critic` |
+| [render](render.md) | Render EDLs and mix video+audio | `edl`, `mix` |
+| [test-provider](utilities.md#test-provider) | Test individual providers | `--prompt`, `--live`, `--output` |
+| [upload](upload.md) | Upload videos to platforms | `youtube`, `youtube-update`, `youtube-auth` |
+| [status](utilities.md#status) | Show system status | `--json` |
+| [providers](providers.md) | List and manage providers | `list`, `add`, `remove` |
+| [kb](kb.md) | Knowledge base management | `create`, `ingest`, `list` |
+| [document](document.md) | Document ingestion | `--pdf`, `--extract-figures` |
+| [training](training.md) | Training pipeline | `run`, `list`, `clean` |
+| [memory](utilities.md#memory) | Memory and learnings management | `show`, `clear` |
+| [qa](utilities.md#qa) | QA inspection | `--run-id`, `--verbose` |
+| [config](utilities.md#config) | Configuration management | `show`, `set`, `reset` |
+| [secrets](utilities.md#secrets) | API key management | `set`, `get`, `list`, `delete` |
+| [themes](utilities.md#themes) | Color themes | `list`, `set` |
+| [agents](utilities.md#agents) | Agent management | `list`, `status` |
+
+## Production Pipeline Overview
+
+The production pipeline follows these stages:
+
+1. **Planning** (Sequential)
+   - ProducerAgent analyzes concept and creates pilot strategies
+   - ScriptWriterAgent generates scene breakdown
+
+2. **Asset Generation** (Parallel via Strands)
+   - VideoGeneratorAgent creates videos using providers (Luma, Runway)
+   - AudioGeneratorAgent generates voiceover and music
+
+3. **Evaluation** (Sequential)
+   - QAVerifierAgent analyzes video quality
+   - CriticAgent scores and approves production
+   - EditorAgent creates Edit Decision Lists (EDLs)
+
+4. **Rendering**
+   - FFmpegRenderer concatenates videos and adds transitions
+
+## Provider Support
+
+### Video Providers
+- **Luma AI** (`luma`) - Text/image to video, 5-10s clips
+- **Runway ML** (`runway`) - Image to video generation
+- **Mock** (`mock`) - Development/testing mode
+
+### Audio Providers  
+- **OpenAI TTS** - Text-to-speech generation
+- **ElevenLabs** - High-quality voice synthesis
+- **Google TTS** - Text-to-speech
+
+### Image Providers
+- **DALL-E 3** - AI image generation
+- **Wikimedia Commons** - Free image sourcing
+
+## Key Features
+
+### Multi-Agent Architecture
+Uses sophisticated agent patterns including:
+- Sequential planning stages (Producer → ScriptWriter)
+- Parallel asset generation (Video + Audio via Strands)
+- Quality evaluation pipeline (QA → Critic → Editor)
+
+### Budget-Aware Production
+- Multiple production tiers (micro, low, medium, high, full)
+- Cost tracking and optimization
+- Provider selection based on budget
+
+### Memory & Learning
+- Long-term memory of production patterns
+- Provider-specific prompt optimization
+- Quality score tracking and analysis
+
+### Unified Production Architecture
+- Structured script parsing and segmentation
+- Content library with asset tracking
+- Assembly manifest for precise timing
+
+## Configuration
+
+Set up API keys using the secrets command:
+
+```bash
+# Core providers
+claude-studio secrets set ANTHROPIC_API_KEY your_key
+claude-studio secrets set LUMA_API_KEY your_key
+claude-studio secrets set OPENAI_API_KEY your_key
+
+# Optional providers
+claude-studio secrets set ELEVENLABS_API_KEY your_key
+claude-studio secrets set RUNWAY_API_KEY your_key
+
+# YouTube upload
+claude-studio secrets set YOUTUBE_CLIENT_ID your_client_id
+claude-studio secrets set YOUTUBE_CLIENT_SECRET your_client_secret
+```
+
+Check status:
+```bash
+claude-studio status
+```
+
+## Environment Variables
+
+Alternative to secrets (lower priority):
+- `ANTHROPIC_API_KEY` - Claude API access
+- `LUMA_API_KEY` - Luma AI video generation  
+- `RUNWAY_API_KEY` - Runway ML video generation
+- `OPENAI_API_KEY` - GPT and DALL-E access
+- `ELEVENLABS_API_KEY` - Voice synthesis
+- `TTS_PROVIDER` - Force TTS provider (`openai` or `elevenlabs`)
+
+## Common Workflows
+
+### Basic Video Production
+```bash
+# 1. Create video concept
+claude-studio produce -c "Product demo for mobile app" -b 20 -d 30 --live -p luma
+
+# 2. Review and render
+claude-studio render edl <run_id>
+
+# 3. Upload to YouTube  
+claude-studio upload youtube video.mp4 -t "Product Demo" --privacy unlisted
+```
+
+### Script-Based Production
+```bash
+# 1. Train on PDF documents
+claude-studio training run --pdf document.pdf
+
+# 2. Generate video from training
+claude-studio produce-video --from-training latest --live --kb my-project
+
+# 3. Assemble rough cut
+claude-studio assemble <run_dir>
+```
+
+### Provider Testing
+```bash
+# Test video generation
+claude-studio test-provider luma -p "A rocket launching" --live
+
+# Test audio generation
+claude-studio test-provider elevenlabs -t "Hello world" --voice lily --live
+```
+
+## Output Structure
+
+Production runs create organized output directories:
+
+```
+artifacts/runs/<run_id>/
+├── scenes/              # Scene specifications
+├── videos/              # Generated video clips
+├── audio/               # Generated audio files
+├── edl/                 # Edit Decision Lists
+├── renders/             # Final rendered videos
+├── assembly/            # Rough cut assembly
+├── metadata.json        # Run metadata
+└── final_output.mp4     # Mixed final video
+```
+
+## Error Handling
+
+Common issues and solutions:
+
+### API Keys
+```bash
+# Check configuration
+claude-studio status
+
+# Set missing keys
+claude-studio secrets set LUMA_API_KEY your_key
+```
+
+### FFmpeg Required
+```bash
+# Install FFmpeg for rendering
+brew install ffmpeg  # macOS
+sudo apt install ffmpeg  # Ubuntu
+```
+
+### Provider Limits
+```bash
+# Use mock mode for development
+claude-studio produce -c "test" --mock
+
+# Test individual providers
+claude-studio test-provider luma -p "test" --live
+```
+
+## Version
+
+Current version: **0.6.0**
+
+For detailed command documentation, see the individual command pages linked in the table above.

--- a/docs/cli/README.md
+++ b/docs/cli/README.md
@@ -1,219 +1,94 @@
-# Claude Studio Producer - CLI Reference
+# Claude Studio Producer — CLI Reference
 
-Claude Studio Producer provides a comprehensive command-line interface for AI video production with multi-agent orchestration.
+Complete CLI reference for the AI video production pipeline.
 
 ## Quick Start
 
 ```bash
 # Quick demo with mock providers
-claude-studio produce -c "Logo reveal for TechCorp" -d 5 --mock
+cs produce -c "Logo reveal for TechCorp" -d 5 --mock
 
 # Live production with Luma
-claude-studio produce -c "Product demo" -b 15 -d 30 --live -p luma
+cs produce -c "Product demo" -b 15 -d 30 --live -p luma
 
 # Generate video from transcript
-claude-studio produce-video --script script.txt --live --kb my-project
+cs produce-video --script script.txt --live --kb my-project
 ```
 
-## Command Overview
+## Command Reference
 
-| Command | Purpose | Key Options |
-|---------|---------|-------------|
-| [produce](produce.md) | Run full video production pipeline | `--concept`, `--budget`, `--live`, `--provider` |
-| [produce-video](produce-video.md) | Generate explainer videos from scripts | `--from-training`, `--script`, `--live`, `--kb-project` |
-| [assemble](assemble.md) | Create rough cut video from production assets | `--output`, `--skip-existing` |
-| [assets](assets.md) | Asset tracking and approval workflow | `list`, `approve`, `reject`, `build` |
-| [resume](resume.md) | Resume interrupted productions | `--live`, `--skip-qa`, `--skip-critic` |
-| [render](render.md) | Render EDLs and mix video+audio | `edl`, `mix` |
-| [test-provider](utilities.md#test-provider) | Test individual providers | `--prompt`, `--live`, `--output` |
-| [upload](upload.md) | Upload videos to platforms | `youtube`, `youtube-update`, `youtube-auth` |
-| [status](utilities.md#status) | Show system status | `--json` |
-| [providers](providers.md) | List and manage providers | `list`, `add`, `remove` |
-| [kb](kb.md) | Knowledge base management | `create`, `ingest`, `list` |
-| [document](document.md) | Document ingestion | `--pdf`, `--extract-figures` |
-| [training](training.md) | Training pipeline | `run`, `list`, `clean` |
-| [memory](utilities.md#memory) | Memory and learnings management | `show`, `clear` |
-| [qa](utilities.md#qa) | QA inspection | `--run-id`, `--verbose` |
-| [config](utilities.md#config) | Configuration management | `show`, `set`, `reset` |
-| [secrets](utilities.md#secrets) | API key management | `set`, `get`, `list`, `delete` |
-| [themes](utilities.md#themes) | Color themes | `list`, `set` |
-| [agents](utilities.md#agents) | Agent management | `list`, `status` |
+### Content & Knowledge
 
-## Production Pipeline Overview
+| Command | Description | Docs |
+|---------|-------------|------|
+| `document` | Ingest PDFs into knowledge graphs | [document.md](document.md) |
+| `kb` | Multi-source knowledge base management | [kb.md](kb.md) |
+| `training` | Podcast calibration from reference pairs | [training.md](training.md) |
 
-The production pipeline follows these stages:
+### Production
 
-1. **Planning** (Sequential)
-   - ProducerAgent analyzes concept and creates pilot strategies
-   - ScriptWriterAgent generates scene breakdown
+| Command | Description | Docs |
+|---------|-------------|------|
+| `produce` | Full video production pipeline | [produce.md](produce.md) |
+| `produce-video` | Explainer video from scripts/training | [produce-video.md](produce-video.md) |
+| `assemble` | Rough cut assembly from production assets | [assemble.md](assemble.md) |
+| `assets` | Asset tracking and approval workflow | [assets.md](assets.md) |
+| `render` | Render EDLs, mix video+audio | [render.md](render.md) |
+| `resume` | Resume interrupted productions | [resume.md](resume.md) |
 
-2. **Asset Generation** (Parallel via Strands)
-   - VideoGeneratorAgent creates videos using providers (Luma, Runway)
-   - AudioGeneratorAgent generates voiceover and music
+### Publishing
 
-3. **Evaluation** (Sequential)
-   - QAVerifierAgent analyzes video quality
-   - CriticAgent scores and approves production
-   - EditorAgent creates Edit Decision Lists (EDLs)
+| Command | Description | Docs |
+|---------|-------------|------|
+| `upload` | YouTube upload, metadata updates, auth | [upload.md](upload.md) |
 
-4. **Rendering**
-   - FFmpegRenderer concatenates videos and adds transitions
+### System & Providers
 
-## Provider Support
+| Command | Description | Docs |
+|---------|-------------|------|
+| `agents` | List and inspect agents | [utilities.md](utilities.md#agents) |
+| `config` | Configuration management | [utilities.md](utilities.md#config) |
+| `luma` | Luma API management (list, download, recover) | [utilities.md](utilities.md#luma) |
+| `memory` | Memory and learnings management | [utilities.md](utilities.md#memory) |
+| `providers` | Provider listing, checking, testing | [providers.md](providers.md) |
+| `qa` | QA inspection of production quality | [utilities.md](utilities.md#qa) |
+| `secrets` | API key management (OS keychain) | [utilities.md](utilities.md#secrets) |
+| `status` | System status | [utilities.md](utilities.md#status) |
+| `test-provider` | Quick single-provider validation | [providers.md](providers.md) |
+| `themes` | Color theme selection | [utilities.md](utilities.md#themes) |
 
-### Video Providers
-- **Luma AI** (`luma`) - Text/image to video, 5-10s clips
-- **Runway ML** (`runway`) - Image to video generation
-- **Mock** (`mock`) - Development/testing mode
+## Typical Workflow
 
-### Audio Providers  
-- **OpenAI TTS** - Text-to-speech generation
-- **ElevenLabs** - High-quality voice synthesis
-- **Google TTS** - Text-to-speech
-
-### Image Providers
-- **DALL-E 3** - AI image generation
-- **Wikimedia Commons** - Free image sourcing
-
-## Key Features
-
-### Multi-Agent Architecture
-Uses sophisticated agent patterns including:
-- Sequential planning stages (Producer → ScriptWriter)
-- Parallel asset generation (Video + Audio via Strands)
-- Quality evaluation pipeline (QA → Critic → Editor)
-
-### Budget-Aware Production
-- Multiple production tiers (micro, low, medium, high, full)
-- Cost tracking and optimization
-- Provider selection based on budget
-
-### Memory & Learning
-- Long-term memory of production patterns
-- Provider-specific prompt optimization
-- Quality score tracking and analysis
-
-### Unified Production Architecture
-- Structured script parsing and segmentation
-- Content library with asset tracking
-- Assembly manifest for precise timing
-
-## Configuration
-
-Set up API keys using the secrets command:
-
-```bash
-# Core providers
-claude-studio secrets set ANTHROPIC_API_KEY your_key
-claude-studio secrets set LUMA_API_KEY your_key
-claude-studio secrets set OPENAI_API_KEY your_key
-
-# Optional providers
-claude-studio secrets set ELEVENLABS_API_KEY your_key
-claude-studio secrets set RUNWAY_API_KEY your_key
-
-# YouTube upload
-claude-studio secrets set YOUTUBE_CLIENT_ID your_client_id
-claude-studio secrets set YOUTUBE_CLIENT_SECRET your_client_secret
+```
+document/kb → training (optional) → produce-video → assemble → upload
 ```
 
-Check status:
+1. **Ingest** — `cs kb create` + `cs kb add --paper` to build a knowledge base
+2. **Script** — `cs kb script` to generate a podcast script from KB content
+3. **Produce** — `cs produce-video --script` to generate video assets
+4. **Assemble** — `cs assemble` to create rough cut
+5. **Upload** — `cs upload youtube` to publish
+
+## Setup
+
 ```bash
-claude-studio status
+# Set API keys via OS keychain
+cs secrets set ANTHROPIC_API_KEY
+cs secrets set OPENAI_API_KEY
+cs secrets set ELEVENLABS_API_KEY  # optional, OpenAI TTS is fallback
+cs secrets set LUMA_API_KEY        # for video generation
+
+# Check everything
+cs status
 ```
 
 ## Environment Variables
 
-Alternative to secrets (lower priority):
-- `ANTHROPIC_API_KEY` - Claude API access
-- `LUMA_API_KEY` - Luma AI video generation  
-- `RUNWAY_API_KEY` - Runway ML video generation
-- `OPENAI_API_KEY` - GPT and DALL-E access
-- `ELEVENLABS_API_KEY` - Voice synthesis
-- `TTS_PROVIDER` - Force TTS provider (`openai` or `elevenlabs`)
-
-## Common Workflows
-
-### Basic Video Production
-```bash
-# 1. Create video concept
-claude-studio produce -c "Product demo for mobile app" -b 20 -d 30 --live -p luma
-
-# 2. Review and render
-claude-studio render edl <run_id>
-
-# 3. Upload to YouTube  
-claude-studio upload youtube video.mp4 -t "Product Demo" --privacy unlisted
-```
-
-### Script-Based Production
-```bash
-# 1. Train on PDF documents
-claude-studio training run --pdf document.pdf
-
-# 2. Generate video from training
-claude-studio produce-video --from-training latest --live --kb my-project
-
-# 3. Assemble rough cut
-claude-studio assemble <run_dir>
-```
-
-### Provider Testing
-```bash
-# Test video generation
-claude-studio test-provider luma -p "A rocket launching" --live
-
-# Test audio generation
-claude-studio test-provider elevenlabs -t "Hello world" --voice lily --live
-```
-
-## Output Structure
-
-Production runs create organized output directories:
-
-```
-artifacts/runs/<run_id>/
-├── scenes/              # Scene specifications
-├── videos/              # Generated video clips
-├── audio/               # Generated audio files
-├── edl/                 # Edit Decision Lists
-├── renders/             # Final rendered videos
-├── assembly/            # Rough cut assembly
-├── metadata.json        # Run metadata
-└── final_output.mp4     # Mixed final video
-```
-
-## Error Handling
-
-Common issues and solutions:
-
-### API Keys
-```bash
-# Check configuration
-claude-studio status
-
-# Set missing keys
-claude-studio secrets set LUMA_API_KEY your_key
-```
-
-### FFmpeg Required
-```bash
-# Install FFmpeg for rendering
-brew install ffmpeg  # macOS
-sudo apt install ffmpeg  # Ubuntu
-```
-
-### Provider Limits
-```bash
-# Use mock mode for development
-claude-studio produce -c "test" --mock
-
-# Test individual providers
-claude-studio test-provider luma -p "test" --live
-```
-
-## Version
-
-Current version: **0.6.0**
-
-For detailed command documentation, see the individual command pages linked in the table above.
+| Variable | Purpose |
+|----------|---------|
+| `ANTHROPIC_API_KEY` | Claude API (content analysis, scripting) |
+| `OPENAI_API_KEY` | DALL-E images + TTS fallback |
+| `ELEVENLABS_API_KEY` | Primary TTS provider |
+| `LUMA_API_KEY` | Luma AI video generation |
+| `RUNWAY_API_KEY` | Runway ML video generation |
+| `TTS_PROVIDER` | Force TTS provider (`openai` to skip ElevenLabs) |

--- a/docs/cli/assemble.md
+++ b/docs/cli/assemble.md
@@ -1,0 +1,456 @@
+# assemble - Rough Cut Video Assembly  
+
+The `assemble` command creates rough cut videos from production assets with precise timing synchronization. This is Phase 5 of the Unified Production Architecture, handling timed assembly with figure sync points and Ken Burns effects.
+
+## Synopsis
+
+```bash
+claude-studio assemble RUN_DIR [OPTIONS]
+```
+
+## Description
+
+The assemble command takes production assets and creates a cohesive video with:
+
+- Synchronized audio-visual timing
+- Ken Burns effects on DALL-E generated images
+- Figure synchronization to narration discussion points
+- Text overlays for content without visuals
+- Smooth transitions between segments
+
+## Required Arguments
+
+### `RUN_DIR`
+Path to a video production run directory.
+
+This should be the output directory from a `produce-video` or `produce` command containing the necessary assets and metadata.
+
+**Examples:**
+- `artifacts/video_production/20260207_143022`
+- `./my_video_project`
+- `../completed_runs/tutorial_video`
+
+## Options
+
+### `--output, -o PATH`
+Output video path.
+
+**Default:** `<run_dir>/assembly/rough_cut.mp4`
+
+**Examples:**
+- `--output final_video.mp4`
+- `--output ./outputs/my_video.mp4`
+
+### `--skip-existing / --no-skip-existing`
+Skip re-rendering existing segments (default: True).
+
+When enabled, segments that already exist will not be re-rendered, speeding up subsequent runs. Disable to force complete re-rendering.
+
+## Examples
+
+### Basic Usage
+
+```bash
+# Assemble from production run directory
+claude-studio assemble artifacts/video_production/20260207_143022
+
+# Custom output location
+claude-studio assemble ./my_run --output final.mp4
+
+# Force complete re-rendering
+claude-studio assemble ./my_run --no-skip-existing
+```
+
+### Typical Workflow
+
+```bash
+# 1. Generate assets
+claude-studio produce-video --script script.txt --live --kb-project my-kb
+
+# 2. Assemble rough cut  
+claude-studio assemble <output_directory>
+
+# 3. Review result
+open <output_directory>/assembly/rough_cut.mp4
+```
+
+## Assembly Process
+
+### Phase 1: Asset Loading
+
+1. **Production Artifacts Discovery**
+   - Loads structured script (if available)
+   - Reads content library with asset registry
+   - Falls back to legacy asset manifest if needed
+
+2. **Audio Analysis**
+   - Discovers audio files by segment
+   - Measures actual audio durations using ffprobe
+   - Builds timing map for video synchronization
+
+3. **Visual Asset Mapping**
+   - Maps images to segments based on content library
+   - Identifies KB figures, DALL-E images, and web images
+   - Plans carry-forward for segments without visuals
+
+### Phase 2: Assembly Manifest Creation
+
+The assembly manifest specifies exactly how each segment should be rendered:
+
+```json
+{
+  "segments": [
+    {
+      "segment_idx": 1,
+      "display_mode": "dall_e",
+      "visual": {"path": "images/scene_001.png"},
+      "audio": {"path": "audio/audio_001.mp3", "duration_sec": 12.5},
+      "text_preview": "Welcome to our explanation..."
+    },
+    {
+      "segment_idx": 2, 
+      "display_mode": "figure_sync",
+      "visual": {"path": "images/kb_figure_002.png"},
+      "audio": {"path": "audio/audio_002.mp3", "duration_sec": 8.3}
+    }
+  ]
+}
+```
+
+### Phase 3: Segment Rendering
+
+Each segment is rendered based on its display mode:
+
+#### `dall_e` Mode
+- DALL-E generated images get Ken Burns effects
+- Smooth zoom from 1.0x to 1.08x scale over duration
+- Ease-in-out motion for professional feel
+
+#### `figure_sync` Mode  
+- KB figures rendered as static holds
+- No zoom effects to preserve figure clarity
+- Perfect for technical diagrams and charts
+
+#### `web_image` Mode
+- Wikimedia/web images as static holds
+- Maintains aspect ratio and centers content
+- No effects to respect source material
+
+#### `carry_forward` Mode
+- Reuses the previous segment's image
+- Maintains visual continuity
+- Static display with new audio
+
+#### `transcript` Mode
+- Karaoke-style text overlay on dark background
+- Word-by-word highlighting as narration progresses
+- Used when no visual assets are available
+
+### Phase 4: Final Assembly
+
+1. **Audio Concatenation**
+   - Combines all segment audio files
+   - Maintains perfect timing synchronization
+   - Creates single master audio track
+
+2. **Video Concatenation**
+   - Joins all rendered video segments
+   - Adds master audio track overlay
+   - Outputs final MP4 with AAC audio
+
+## Display Modes Explained
+
+### Ken Burns Effects (`dall_e`)
+
+Applied to AI-generated images for engaging visual movement:
+
+```
+Initial: 1920x1080 centered image, scale=1.0
+Final:   1920x1080 centered image, scale=1.08
+Motion:  Smooth ease-in-out zoom over segment duration
+```
+
+Benefits:
+- Adds professional visual interest
+- Prevents static appearance
+- Subtle enough not to distract from content
+
+### Static Hold (all others)
+
+Used for:
+- **KB Figures**: Preserves technical accuracy
+- **Web Images**: Respects source licensing  
+- **Carry Forward**: Maintains visual continuity
+
+No zoom or pan effects to ensure:
+- Text in figures remains readable
+- Charts and diagrams stay clear
+- Attribution requirements are met
+
+### Karaoke Text (`transcript`)
+
+Progressive word highlighting:
+- **White**: Current word being spoken
+- **Grey**: Already spoken words  
+- **Dark grey**: Upcoming words
+- **Black shadow**: Text outline for readability
+
+Font: OpenDyslexic with fallback to system fonts
+
+## Timing Synchronization
+
+### Audio-Led Timing
+
+Assembly uses actual audio durations to drive video timing:
+
+1. **Audio Measurement**: Each audio file probed for exact duration
+2. **Video Matching**: Video segments stretched/cropped to match audio
+3. **Perfect Sync**: No drift between audio and visual content
+
+### Figure Sync Points
+
+When KB figures are used:
+- Figures appear when narration discusses them
+- Timing based on content analysis from structured script
+- Visual-audio alignment for maximum comprehension
+
+## Output Structure
+
+Assembly creates organized output:
+
+```
+<run_dir>/assembly/
+├── segments/                   # Individual video segments
+│   ├── segment_001.mp4
+│   ├── segment_002.mp4
+│   └── ...
+├── audio_combined.mp3         # Master audio track
+├── rough_cut.mp4              # Final assembled video
+└── assembly_manifest.json     # Assembly instructions
+```
+
+### Assembly Manifest
+
+The manifest documents the assembly process:
+
+```json
+{
+  "assembly_id": "asm_20260207_143022",
+  "created_at": "2026-02-07T14:30:22Z",
+  "total_segments": 15,
+  "total_duration_sec": 180.5,
+  "segments": [
+    {
+      "segment_idx": 1,
+      "display_mode": "dall_e",
+      "start_time": 0.0,
+      "end_time": 12.5,
+      "visual": {
+        "path": "images/scene_001.png",
+        "source": "dalle",
+        "status": "approved"
+      },
+      "audio": {
+        "path": "audio/audio_001.mp3", 
+        "duration_sec": 12.5,
+        "source": "elevenlabs"
+      }
+    }
+  ]
+}
+```
+
+## Quality Control
+
+### Pre-Assembly Checks
+
+The assembler performs validation:
+
+1. **Asset Availability**: Verifies all required files exist
+2. **Duration Matching**: Ensures audio and visual alignment
+3. **Format Compatibility**: Checks file formats are supported
+4. **Resolution Consistency**: Validates video dimensions
+
+### Error Recovery
+
+- **Missing Images**: Falls back to transcript overlay mode
+- **Missing Audio**: Creates silent segments with visual-only
+- **Corrupt Files**: Skips problematic segments with warnings
+- **Duration Mismatches**: Adjusts timing to prevent sync issues
+
+## Integration with Asset Management
+
+Assembly respects asset approval status:
+
+```bash
+# Review assets before assembly
+claude-studio assets list <run_dir>
+
+# Approve specific assets
+claude-studio assets approve <run_dir> --image 1,3,5 --audio all
+
+# Assemble with approved assets only
+claude-studio assemble <run_dir>
+```
+
+Assets with `rejected` status are handled gracefully:
+- Rejected images fall back to text overlay
+- Rejected audio creates silent segments
+- Assembly continues with available assets
+
+## Performance Optimization
+
+### Segment Caching
+
+The `--skip-existing` option (default: True) provides:
+- **Fast Iteration**: Only render changed segments
+- **Resumable Assembly**: Continue after interruptions
+- **Selective Updates**: Update specific segments only
+
+### FFmpeg Optimization
+
+Assembly uses optimized FFmpeg settings:
+- **Fast Preset**: Balanced quality and speed
+- **CRF 23**: High quality with reasonable file size
+- **AAC Audio**: Universal compatibility at 192kbps
+- **YUV420P**: Maximum player compatibility
+
+## System Requirements
+
+### FFmpeg Required
+
+Assembly requires FFmpeg installation:
+
+```bash
+# macOS
+brew install ffmpeg
+
+# Ubuntu/Debian  
+sudo apt install ffmpeg
+
+# Windows
+# Download from https://ffmpeg.org/
+```
+
+### File System
+
+- **Disk Space**: ~2x final video size for temporary files
+- **Permissions**: Write access to run directory
+- **Format Support**: PNG, JPG, MP3, MP4 file handling
+
+## Troubleshooting
+
+### Common Issues
+
+#### FFmpeg Not Found
+```bash
+Error: FFmpeg not installed
+```
+**Solution:** Install FFmpeg using system package manager
+
+#### Missing Assets
+```bash
+Warning: Image not found: images/scene_005.png
+```
+**Solution:** Check asset generation completed successfully
+
+#### Audio Sync Issues
+```bash
+Warning: Audio duration mismatch: expected 10s, got 8s  
+```
+**Solution:** Regenerate audio or use `--no-skip-existing`
+
+#### Permission Errors
+```bash
+Error: Permission denied writing to assembly/rough_cut.mp4
+```
+**Solution:** Check directory permissions and disk space
+
+### Debug Mode
+
+For detailed troubleshooting:
+
+```bash
+# Enable verbose output
+claude-studio assemble <run_dir> --output debug.mp4 2>&1 | tee assembly.log
+
+# Check assembly manifest
+cat <run_dir>/assembly/assembly_manifest.json | jq .
+
+# Verify individual segments
+ls -la <run_dir>/assembly/segments/
+```
+
+## Advanced Usage
+
+### Custom Processing
+
+For specialized assembly requirements:
+
+```bash
+# Force complete re-render
+claude-studio assemble <run_dir> --no-skip-existing
+
+# Assembly with custom timing
+# (Modify assembly manifest then assemble)
+vim <run_dir>/assembly/assembly_manifest.json
+claude-studio assemble <run_dir> --no-skip-existing
+```
+
+### Batch Processing
+
+```bash
+# Assemble multiple runs
+for run_dir in artifacts/video_production/*/; do
+  claude-studio assemble "$run_dir" --output "final_$(basename "$run_dir").mp4"
+done
+```
+
+### Pipeline Integration
+
+```bash
+#!/bin/bash
+# Complete video production pipeline
+
+# Generate assets
+claude-studio produce-video --script "$1" --live --kb-project research
+
+# Get output directory
+OUTPUT_DIR=$(ls -t artifacts/video_production/ | head -1)
+
+# Assemble video
+claude-studio assemble "artifacts/video_production/$OUTPUT_DIR"
+
+# Upload result
+claude-studio upload youtube \
+  "artifacts/video_production/$OUTPUT_DIR/assembly/rough_cut.mp4" \
+  --title "$(basename "$1" .txt)" \
+  --privacy unlisted
+```
+
+## Quality Settings
+
+Assembly provides high-quality output optimized for:
+
+### Video Quality
+- **Resolution**: 1920x1080 (Full HD)
+- **Codec**: H.264 with CRF 23
+- **Frame Rate**: 30fps for smooth playback
+- **Color Space**: YUV420P for compatibility
+
+### Audio Quality  
+- **Codec**: AAC-LC
+- **Bitrate**: 192kbps (high quality)
+- **Sample Rate**: 44.1kHz or original
+- **Channels**: Stereo or original
+
+### File Optimization
+- **Container**: MP4 for universal compatibility
+- **Seeking**: Optimized for web streaming
+- **Metadata**: Includes creation timestamp and source info
+
+## Version History
+
+- **0.6.0**: Unified Production Architecture with content library
+- **0.5.x**: Ken Burns effects and figure synchronization
+- **0.4.x**: Basic segment concatenation

--- a/docs/cli/assets.md
+++ b/docs/cli/assets.md
@@ -1,0 +1,633 @@
+# assets - Asset Tracking and Approval  
+
+The `assets` command provides comprehensive asset tracking and approval workflow for production assets. This is Phase 6 of the Unified Production Architecture, enabling fine-grained control over which assets are used in final video builds.
+
+## Synopsis
+
+```bash
+claude-studio assets COMMAND [OPTIONS]
+```
+
+## Description
+
+The assets command manages the complete lifecycle of production assets:
+
+- Review generated images, audio, and video clips
+- Approve high-quality assets for final builds  
+- Reject problematic assets for regeneration
+- Import approved assets between production runs
+- Build final videos using only approved content
+
+## Commands Overview
+
+| Command | Purpose |
+|---------|---------|
+| `list` | List assets with filtering options |
+| `approve` | Mark assets as approved for final build |
+| `reject` | Mark assets as rejected (need regeneration) |
+| `build` | Build final video from approved assets |
+| `import` | Import assets from another production run |
+| `summary` | Show asset status summary |
+
+## Workflow
+
+The typical asset management workflow:
+
+```bash
+# 1. Generate assets
+claude-studio produce-video --script script.txt --live --kb-project research
+
+# 2. Review generated assets
+claude-studio assets list <run_dir>
+
+# 3. Approve good assets
+claude-studio assets approve <run_dir> --audio all --image 1,3,5,7
+
+# 4. Reject problematic assets
+claude-studio assets reject <run_dir> --image 2,6 --reason "wrong style"
+
+# 5. Build final video from approved assets
+claude-studio assets build <run_dir>
+```
+
+---
+
+## list - List Assets
+
+List assets in a production run with optional filtering.
+
+### Synopsis
+
+```bash
+claude-studio assets list RUN_DIR [OPTIONS]
+```
+
+### Options
+
+#### `--status, -s CHOICE`
+Filter by asset status.
+
+**Choices:**
+- `all` - Show all assets (default)
+- `draft` - Assets in draft status
+- `review` - Assets pending review
+- `approved` - Assets approved for final build
+- `rejected` - Assets marked for regeneration
+
+#### `--type, -t CHOICE`
+Filter by asset type.
+
+**Choices:**
+- `all` - All asset types (default)
+- `audio` - Audio files only
+- `image` - Image files only  
+- `figure` - KB figures only
+- `video` - Video clips only
+
+#### `--segment, -g TEXT`
+Filter by segment range.
+
+**Format:** 
+- `1-10` - Range of segments
+- `5,6,7` - Specific segments
+- `all` - All segments
+
+### Examples
+
+```bash
+# List all assets
+claude-studio assets list ./my_run
+
+# Show only rejected images
+claude-studio assets list ./my_run --status rejected --type image
+
+# Show assets for segments 1-10
+claude-studio assets list ./my_run --segment 1-10
+
+# Show approved audio assets
+claude-studio assets list ./my_run --status approved --type audio
+```
+
+### Sample Output
+
+```
+┌─ IMAGE Assets (8) ─────────────────────────────────┐
+│ ID                  │ Segment │ Status    │ Path            │
+├─────────────────────┼─────────┼───────────┼─────────────────┤
+│ img_0001            │ 1       │ approved  │ scene_001.png   │
+│ img_0002            │ 2       │ rejected  │ scene_002.png   │
+│ img_0003            │ 3       │ draft     │ scene_003.png   │
+└─────────────────────┴─────────┴───────────┴─────────────────┘
+
+Status breakdown: approved: 5, rejected: 2, draft: 1
+```
+
+---
+
+## approve - Approve Assets
+
+Mark assets as approved for final build.
+
+### Synopsis
+
+```bash
+claude-studio assets approve RUN_DIR [OPTIONS]
+```
+
+### Options
+
+#### `--audio, -a TEXT`
+Audio segments to approve.
+
+**Format:**
+- `all` - Approve all audio assets
+- `1-10` - Approve segments 1 through 10
+- `1,3,5` - Approve specific segments
+
+#### `--image, -i TEXT`  
+Image segments to approve.
+
+**Format:** Same as `--audio`
+
+#### `--segment, -g TEXT`
+Approve all asset types for specified segments.
+
+**Format:** Same as `--audio`
+
+### Examples
+
+```bash
+# Approve all audio assets
+claude-studio assets approve ./my_run --audio all
+
+# Approve specific image segments
+claude-studio assets approve ./my_run --image 1,3,5,7,9
+
+# Approve all assets for segments 1-10
+claude-studio assets approve ./my_run --segment 1-10
+
+# Approve different types separately
+claude-studio assets approve ./my_run --audio 1-5 --image 1,2,4
+```
+
+---
+
+## reject - Reject Assets
+
+Mark assets as rejected, indicating they need regeneration.
+
+### Synopsis
+
+```bash
+claude-studio assets reject RUN_DIR [OPTIONS]
+```
+
+### Options
+
+#### `--audio, -a TEXT`
+Audio segments to reject.
+
+**Format:** Same as approve command
+
+#### `--image, -i TEXT`
+Image segments to reject.
+
+**Format:** Same as approve command
+
+#### `--reason, -r TEXT`
+Reason for rejection (stored in asset metadata).
+
+### Examples
+
+```bash
+# Reject specific images with reason
+claude-studio assets reject ./my_run --image 2,6 --reason "wrong style"
+
+# Reject audio segments
+claude-studio assets reject ./my_run --audio 5-10 --reason "voice too fast"
+
+# Reject without specific reason
+claude-studio assets reject ./my_run --image 3
+```
+
+---
+
+## build - Build Final Video
+
+Build final video using approved assets only.
+
+### Synopsis
+
+```bash
+claude-studio assets build RUN_DIR [OPTIONS]
+```
+
+### Options
+
+#### `--output, -o PATH`
+Output video path.
+
+**Default:** `<run_dir>/final/output.mp4`
+
+#### `--only CHOICE`
+Asset selection strategy.
+
+**Choices:**
+- `approved` - Use only approved assets (default)
+- `all` - Use all available assets
+
+#### `--skip-rejected / --include-rejected`
+Whether to skip rejected assets (default: skip).
+
+### Examples
+
+```bash
+# Build from approved assets only
+claude-studio assets build ./my_run
+
+# Build from all assets except rejected
+claude-studio assets build ./my_run --only all --skip-rejected
+
+# Custom output location
+claude-studio assets build ./my_run --output final_video.mp4
+```
+
+---
+
+## import - Import Assets
+
+Import approved assets from another production run.
+
+### Synopsis
+
+```bash
+claude-studio assets import SOURCE_RUN TARGET_RUN [OPTIONS]
+```
+
+### Options
+
+#### `--status, -s CHOICE`
+Import asset status filter.
+
+**Choices:**
+- `approved` - Import only approved assets (default)
+- `all` - Import all assets
+
+#### `--type, -t CHOICE`
+Import asset type filter.
+
+**Choices:**
+- `all` - Import all asset types (default)
+- `audio` - Import audio assets only
+- `image` - Import image assets only
+
+### Examples
+
+```bash
+# Import all approved assets
+claude-studio assets import ./old_run ./new_run
+
+# Import only approved audio (reuse voiceovers)
+claude-studio assets import ./old_run ./new_run --type audio
+
+# Import all assets regardless of status
+claude-studio assets import ./old_run ./new_run --status all
+```
+
+### Use Cases
+
+**Reusing Approved Audio:**
+When regenerating images but keeping good voiceover:
+
+```bash
+# Generate new images with different style
+claude-studio produce-video --script script.txt --budget high --live
+
+# Import approved audio from previous run  
+claude-studio assets import ./previous_run ./new_run --type audio
+
+# Build with mixed assets
+claude-studio assets build ./new_run
+```
+
+**Template Reuse:**
+Reusing assets across similar content:
+
+```bash
+# Import approved brand assets
+claude-studio assets import ./brand_template ./new_project --type image
+
+# Add project-specific content
+claude-studio produce-video --script new_script.txt --live
+```
+
+---
+
+## summary - Asset Summary
+
+Show comprehensive asset status summary.
+
+### Synopsis
+
+```bash
+claude-studio assets summary RUN_DIR
+```
+
+### Examples
+
+```bash
+# Show complete asset breakdown
+claude-studio assets summary ./my_run
+```
+
+### Sample Output
+
+```
+┌─ Asset Summary: my_run ────────────────────────────┐
+
+Asset Type    │ Count
+──────────────┼──────
+audio         │ 12
+image         │ 15  
+figure        │ 3
+video         │ 8
+Total         │ 38
+
+Status        │ Count  
+──────────────┼──────
+approved      │ 22
+draft         │ 10
+rejected      │ 4
+review        │ 2
+```
+
+---
+
+## Asset Status Lifecycle
+
+Assets progress through defined status states:
+
+### `draft`
+- Initial status after generation
+- Asset available but not reviewed
+- **Color:** Yellow
+
+### `review`  
+- Manually set for assets pending review
+- Intermediate state for workflow
+- **Color:** Cyan
+
+### `approved`
+- Asset approved for final builds
+- High quality, ready for use
+- **Color:** Green
+
+### `rejected`
+- Asset marked for regeneration
+- Quality issues or wrong content
+- **Color:** Red
+
+### `revised`
+- Asset regenerated after rejection
+- Updated version available
+- **Color:** Magenta
+
+## Asset Types
+
+The system tracks multiple asset types:
+
+### `audio`
+- Generated voiceover files
+- TTS output from ElevenLabs/OpenAI
+- Background music tracks
+
+### `image`
+- DALL-E generated images
+- Web-sourced images from Wikimedia
+- Static visual content
+
+### `figure`
+- KB extracted figures from PDFs
+- Technical diagrams and charts
+- Academic/research visuals
+
+### `video`
+- Luma AI generated video clips
+- Runway ML animations
+- Dynamic visual content
+
+## Content Library Integration
+
+Assets are managed through the Content Library system:
+
+### Registration
+Every generated asset is automatically registered:
+
+```json
+{
+  "asset_id": "img_0001",
+  "asset_type": "image",
+  "source": "dalle",
+  "status": "draft",
+  "segment_idx": 1,
+  "path": "images/scene_001.png",
+  "metadata": {
+    "prompt": "A rocket launching into space",
+    "cost": 0.08,
+    "generation_time": "2026-02-07T14:30:22Z"
+  }
+}
+```
+
+### Tracking
+- Generation costs and timing
+- Source provider information
+- Quality metrics and scores
+- Approval workflow history
+
+### Persistence
+Asset status persists across:
+- Assembly operations
+- Build processes  
+- Import/export between runs
+- Long-term project management
+
+## Quality Control Workflow
+
+### Automated Quality Gates
+
+Some quality checks are automatic:
+- **Technical Validation**: File format, resolution, duration
+- **Content Filtering**: Basic content appropriateness
+- **Cost Tracking**: Budget compliance monitoring
+
+### Manual Review Process
+
+```bash
+# 1. Generate assets
+claude-studio produce-video --script script.txt --live
+
+# 2. Review all assets systematically
+claude-studio assets list <run_dir> --status draft
+
+# 3. Spot-check generated content
+open <run_dir>/images/  # Review images
+open <run_dir>/audio/   # Listen to audio
+
+# 4. Approve high-quality assets
+claude-studio assets approve <run_dir> --audio all
+claude-studio assets approve <run_dir> --image 1,3,5,7,9,11
+
+# 5. Reject problematic assets with reasons
+claude-studio assets reject <run_dir> --image 2,4 --reason "off-brand colors"
+claude-studio assets reject <run_dir> --image 6 --reason "unclear diagram"
+
+# 6. Build final video with approved assets only
+claude-studio assets build <run_dir>
+```
+
+### Batch Approval Strategies
+
+**Conservative Approach** (High Quality):
+```bash
+# Review everything individually, approve selectively
+claude-studio assets list <run_dir>
+# ... manual review ...
+claude-studio assets approve <run_dir> --image 1,3,7  # Only best images
+claude-studio assets approve <run_dir> --audio 1-5    # Good audio range
+```
+
+**Aggressive Approach** (Fast Turnaround):
+```bash
+# Approve most, reject only obvious problems
+claude-studio assets approve <run_dir> --audio all
+claude-studio assets approve <run_dir> --image all
+claude-studio assets reject <run_dir> --image 4,7 --reason "technical issues"
+```
+
+**Mixed Approach** (Balanced):
+```bash
+# Approve safe assets, review risky ones
+claude-studio assets approve <run_dir> --audio all  # Audio usually good
+claude-studio assets list <run_dir> --type image    # Review images individually
+claude-studio assets approve <run_dir> --image 1,2,3,5,6,8,9
+claude-studio assets reject <run_dir> --image 4,7 --reason "style mismatch"
+```
+
+## Integration with Other Commands
+
+### Assembly Integration
+
+The `assemble` command respects asset approval:
+
+```bash
+# Assembly uses approved assets automatically
+claude-studio assemble <run_dir>
+```
+
+If assets are rejected, assembly handles gracefully:
+- **Rejected images** → Falls back to text overlay
+- **Rejected audio** → Creates silent segments  
+- **Missing assets** → Uses previous segment's visual
+
+### Production Pipeline Integration
+
+Assets integrate with the full production pipeline:
+
+```bash
+# 1. Generate with quality focus
+claude-studio produce-video --script script.txt --live --budget high
+
+# 2. Review and curate assets
+claude-studio assets list <run_dir>
+claude-studio assets approve <run_dir> --audio all --image 1,3,5,7
+
+# 3. Regenerate rejected assets (manual process)
+# Edit script or regenerate individual segments as needed
+
+# 4. Build final video
+claude-studio assets build <run_dir>
+
+# 5. Upload approved content
+claude-studio upload youtube <run_dir>/final/output.mp4
+```
+
+## Storage and Organization
+
+### File Structure
+
+```
+<run_dir>/
+├── content_library.json    # Asset registry
+├── images/                 # Generated images
+│   ├── scene_001.png      # Status tracked in library
+│   ├── scene_002.png      
+│   └── ...
+├── audio/                  # Generated audio
+│   ├── audio_001.mp3      # Status tracked in library
+│   └── ...
+└── final/                  # Final build outputs
+    └── output.mp4
+```
+
+### Metadata Storage
+
+Asset metadata is stored in `content_library.json`:
+
+```json
+{
+  "project_id": "video_production_20260207_143022",
+  "created_at": "2026-02-07T14:30:22Z",
+  "assets": {
+    "img_0001": {
+      "asset_id": "img_0001",
+      "asset_type": "image", 
+      "status": "approved",
+      "segment_idx": 1,
+      "path": "images/scene_001.png",
+      "source": "dalle",
+      "created_at": "2026-02-07T14:32:15Z",
+      "approved_at": "2026-02-07T14:45:30Z",
+      "metadata": {
+        "prompt": "Professional office workspace with laptop",
+        "cost": 0.08,
+        "width": 1792,
+        "height": 1024
+      }
+    }
+  }
+}
+```
+
+## Performance and Scalability
+
+### Large Production Runs
+
+For productions with many assets:
+
+```bash
+# Use filtering to manage large asset sets
+claude-studio assets list <run_dir> --segment 1-10 --status draft
+claude-studio assets approve <run_dir> --segment 1-10 --audio all
+
+# Batch process by type
+claude-studio assets list <run_dir> --type audio --status draft
+claude-studio assets approve <run_dir> --audio all
+```
+
+### Cross-Project Asset Management
+
+```bash
+# Standardize approved assets across projects
+claude-studio assets import ./template_run ./project1 --type image --status approved
+claude-studio assets import ./template_run ./project2 --type image --status approved
+
+# Share high-quality voiceovers
+claude-studio assets import ./master_audio ./new_project --type audio
+```
+
+## Version History
+
+- **0.6.0**: Unified Production Architecture with content library
+- **0.5.x**: Asset approval workflow and status tracking
+- **0.4.x**: Basic asset listing and management

--- a/docs/cli/document.md
+++ b/docs/cli/document.md
@@ -1,0 +1,59 @@
+# Document Ingestion (`cs document`)
+
+Ingest documents (PDFs) into knowledge graphs for video production. Extracts text, figures, and structure using PyMuPDF, then classifies atoms with LLM.
+
+## Commands
+
+| Command | Description |
+|---------|-------------|
+| `document ingest` | Ingest a PDF and extract knowledge atoms |
+| `document show` | Show a project's document graph |
+| `document list` | List ingested documents |
+
+---
+
+## `document ingest`
+
+```bash
+cs document ingest paper.pdf
+cs document ingest paper.pdf --mock
+cs document ingest paper.pdf -n "My Paper" -o ./output/
+```
+
+**Arguments:**
+- `SOURCE` — Path to PDF file (required)
+
+**Options:**
+| Option | Type | Description |
+|--------|------|-------------|
+| `--mock` | flag | Use mock analysis (no LLM calls) |
+| `-n`, `--project-name` | string | Project name (defaults to filename) |
+| `-o`, `--output-dir` | path | Output directory (default: `artifacts/projects/`) |
+
+**Process:**
+1. Extracts content with PyMuPDF (text, figures, tables)
+2. Classifies atoms by type (abstract, paragraph, figure, quote, etc.)
+3. Generates summaries and extracts topics/entities
+4. Builds a document graph with relationships
+
+---
+
+## `document show`
+
+Show details of an ingested document project.
+
+```bash
+cs document show <project_id>
+```
+
+---
+
+## `document list`
+
+List all ingested document projects.
+
+```bash
+cs document list
+```
+
+**Note:** For multi-source projects, prefer `cs kb` which builds unified knowledge graphs across multiple documents.

--- a/docs/cli/kb.md
+++ b/docs/cli/kb.md
@@ -1,0 +1,215 @@
+# Knowledge Base (`cs kb`)
+
+Manage multi-source knowledge projects for video production. Ingest papers, build knowledge graphs, inspect quality, generate scripts, and produce videos from curated content.
+
+## Commands
+
+| Command | Description |
+|---------|-------------|
+| `kb create` | Create a new knowledge project |
+| `kb add` | Add a source (PDF or note) to a project |
+| `kb show` | Show project overview |
+| `kb sources` | List sources in a project |
+| `kb list` | List all knowledge projects |
+| `kb remove` | Remove a knowledge project |
+| `kb inspect` | Inspect knowledge graph quality |
+| `kb script` | Generate a podcast script from KB content |
+| `kb produce` | Produce a video from KB content |
+
+---
+
+## `kb create`
+
+Create a new knowledge project.
+
+```bash
+cs kb create "CRISPR Research"
+cs kb create "AI Safety" -d "Papers on alignment" -t safety -t alignment
+```
+
+**Arguments:**
+- `NAME` — Project name (required)
+
+**Options:**
+| Option | Type | Description |
+|--------|------|-------------|
+| `-d`, `--description` | string | Project description |
+| `-t`, `--tags` | string (multiple) | Tags for the project |
+
+---
+
+## `kb add`
+
+Add a source to a knowledge project. Supports PDF papers and text notes.
+
+```bash
+cs kb add my-project --paper paper.pdf
+cs kb add my-project --paper paper.pdf --mock
+cs kb add my-project --note "Key insight about the topic"
+cs kb add my-project --paper paper.pdf --title "Custom Title"
+```
+
+**Arguments:**
+- `PROJECT` — Project name, ID, or ID prefix
+
+**Options:**
+| Option | Type | Description |
+|--------|------|-------------|
+| `--paper` | path | PDF paper to add |
+| `--note` | string | Add a text note as a source |
+| `-t`, `--title` | string | Override source title |
+| `--mock` | flag | Use mock analysis (no LLM calls) |
+
+Adding a paper triggers document ingestion (PyMuPDF extraction + LLM atom classification) and rebuilds the unified knowledge graph with cross-source links.
+
+---
+
+## `kb show`
+
+Show overview of a knowledge project.
+
+```bash
+cs kb show my-project
+cs kb show my-project --graph
+```
+
+**Arguments:**
+- `PROJECT` — Project name, ID, or ID prefix
+
+**Options:**
+| Option | Type | Description |
+|--------|------|-------------|
+| `-g`, `--graph` | flag | Show knowledge graph stats (cross-links, shared topics/entities, key themes) |
+
+---
+
+## `kb sources`
+
+List sources in a knowledge project.
+
+```bash
+cs kb sources my-project
+cs kb sources my-project -v
+```
+
+**Arguments:**
+- `PROJECT` — Project name, ID, or ID prefix
+
+**Options:**
+| Option | Type | Description |
+|--------|------|-------------|
+| `-v`, `--verbose` | flag | Show detailed info per source |
+
+---
+
+## `kb list`
+
+List all knowledge projects.
+
+```bash
+cs kb list
+```
+
+---
+
+## `kb remove`
+
+Remove a knowledge project and all its data.
+
+```bash
+cs kb remove my-project
+cs kb remove kb_256dc --force
+```
+
+**Arguments:**
+- `PROJECT` — Project name, ID, or ID prefix
+
+**Options:**
+| Option | Type | Description |
+|--------|------|-------------|
+| `-f`, `--force` | flag | Skip confirmation prompt |
+
+---
+
+## `kb inspect`
+
+Inspect knowledge graph quality and content. Provides quality scores for topics, entities, and atom distribution.
+
+```bash
+cs kb inspect myproject --quality
+cs kb inspect myproject --topics
+cs kb inspect myproject --entities
+cs kb inspect myproject --atoms -n 5
+cs kb inspect myproject -s src_abc123
+cs kb inspect --file path/to/knowledge_graph.json
+```
+
+**Arguments:**
+- `PROJECT` — Project name, ID, or ID prefix (optional if using `--file`)
+
+**Options:**
+| Option | Type | Description |
+|--------|------|-------------|
+| `-f`, `--file` | path | Inspect a knowledge graph JSON file directly |
+| `--topics` | flag | Show topic distribution and quality |
+| `--entities` | flag | Show entity extraction quality |
+| `--atoms` | flag | Sample atoms by type |
+| `--quality` | flag | Full quality report (default if no option given) |
+| `-n`, `--sample` | int | Number of samples per category (default: 3) |
+| `-s`, `--source` | string | Inspect specific source ID only |
+
+---
+
+## `kb script`
+
+Generate a podcast script from KB content without requiring training data.
+
+```bash
+cs kb script "Colleague Paper"
+cs kb script myproject -p "Focus on the methodology" -d 900
+cs kb script myproject --style deep_dive -o my_script.txt
+```
+
+**Arguments:**
+- `PROJECT` — Project name, ID, or ID prefix
+
+**Options:**
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `-p`, `--prompt` | string | auto | Focus/direction for the script |
+| `-d`, `--duration` | float | 600.0 | Target duration in seconds |
+| `--style` | choice | conversational | Script style: `conversational`, `educational`, `documentary`, `deep_dive` |
+| `-s`, `--sources` | string (multiple) | all | Limit to specific source IDs |
+| `-o`, `--output` | path | auto | Output file path |
+| `--structured/--flat` | flag | structured | Also save structured JSON |
+
+Outputs both a plain text script and a structured JSON version with segments.
+
+---
+
+## `kb produce`
+
+Produce a video directly from knowledge base content.
+
+```bash
+cs kb produce "AI Research" -p "Explain the key findings" --mock
+cs kb produce myproject -p "Compare the two papers" --tier animated --live
+```
+
+**Arguments:**
+- `PROJECT` — Project name, ID, or ID prefix
+
+**Options:**
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `-p`, `--prompt` | string | **required** | Production direction/focus |
+| `-s`, `--sources` | string (multiple) | all | Limit to specific source IDs |
+| `--tier` | choice | static | Visual tier: `static`, `text`, `animated`, `broll`, `avatar`, `full` |
+| `-d`, `--duration` | float | 60.0 | Target duration in seconds |
+| `-b`, `--budget` | float | 10.0 | Budget in USD |
+| `--provider` | choice | luma | Video provider: `luma`, `runway`, `mock` |
+| `--audio-tier` | choice | simple_overlay | `none`, `music_only`, `simple_overlay`, `time_synced` |
+| `--live` | flag | | Use live providers (costs money) |
+| `--mock` | flag | | Force mock mode |
+| `--debug` | flag | | Enable debug output |
+| `--style` | choice | visual_storyboard | `visual_storyboard`, `podcast`, `educational`, `documentary` |

--- a/docs/cli/produce-video.md
+++ b/docs/cli/produce-video.md
@@ -1,516 +1,90 @@
-# produce-video - Explainer Videos from Scripts
+# produce-video — Explainer Videos from Scripts
 
-The `produce-video` command generates explainer videos from podcast scripts and documents using the Unified Production Architecture. This command creates transcript-led video production with figure synchronization and budget-aware asset generation.
+Generate explainer videos from podcast scripts or training output.
 
 ## Synopsis
 
 ```bash
-claude-studio produce-video [--from-training TRIAL_ID | --script PATH] [OPTIONS]
+cs produce-video [OPTIONS]
 ```
 
-## Description
+## Input Sources
 
-The produce-video command specializes in creating educational and explanatory videos from structured content. It supports:
+Provide one of:
 
-- Training-based production from analyzed documents
-- Direct script-to-video conversion
-- Knowledge base figure integration
-- Budget-aware asset allocation
-- Multi-tier cost optimization
-
-## Input Sources (Required)
-
-Choose one input source:
-
-### `--from-training TRIAL_ID`
-Load content from a training trial.
-
-Training trials are created by the `training run` command and contain:
-- Aligned transcript segments
-- Knowledge graphs with figure references  
-- Style and structure profiles
-- Pre-analyzed content hierarchy
-
-**Examples:**
-- `--from-training latest` - Use most recent training
-- `--from-training 20260207_143022` - Specific trial ID
-
-### `--script PATH`
-Generate directly from a script file.
-
-Script files should contain well-structured text with natural paragraph breaks (double newlines). This mode bypasses training requirements but provides less sophisticated content analysis.
-
-**Examples:**
-- `--script my_script.txt`
-- `--script ./content/podcast_transcript.md`
+| Option | Description |
+|--------|-------------|
+| `-t`, `--from-training TRIAL_ID` | Use output from a training trial |
+| `-s`, `--script PATH` | Path to a podcast script file |
 
 ## Options
 
-### Core Options
-
-#### `--output PATH`
-Output directory path (default: `artifacts/video_production/<timestamp>`).
-
-#### `--live`
-Use live API providers (costs money!). 
-
-When not specified, runs in mock mode with simulated assets.
-
-#### `--style CHOICE`
-Narrative style for video production.
-
-**Choices:**
-- `visual_storyboard` - Visual-focused narrative (default)
-- `podcast` - Rich NotebookLM-style narration
-- `educational` - Educational lecture format  
-- `documentary` - Documentary style
-
-### Knowledge Base Integration
-
-#### `--kb-project TEXT`
-Knowledge base project name for figure integration.
-
-Enables automatic figure matching and seeding for video generation. The KB project should be created and populated using the `kb` commands.
-
-**Example:**
-```bash
-# First create and populate KB
-claude-studio kb create my-research
-claude-studio kb ingest my-research --pdf research.pdf
-
-# Then use in video production
-claude-studio produce-video --script script.txt --kb-project my-research
-```
-
-### Budget Control
-
-#### `--budget CHOICE`
-Budget tier for asset generation.
-
-**Choices:**
-- `micro` - Text overlays and minimal images
-- `low` - Basic DALL-E images, shared assets
-- `medium` - Full DALL-E + some animations
-- `high` - Premium generation with Luma animations  
-- `full` - Maximum quality, all animations
-
-**Budget Impact:**
-- Higher tiers enable more DALL-E generations
-- Animation allocation increases with budget
-- Figure seeding optimizes across all tiers
-
-#### `--show-tiers`
-Display budget tier comparison table and exit.
-
-Shows detailed cost breakdown for each tier based on script analysis.
-
-### Content Filtering
-
-#### `--scene-limit INTEGER`
-Maximum number of scenes to process.
-
-Useful for testing or partial generation. Processes scenes from `--scene-start` up to the limit.
-
-#### `--scene-start INTEGER`
-Starting scene index (default: 0).
-
-Combined with `--scene-limit` allows processing specific scene ranges.
-
-**Example:**
-```bash
-# Process scenes 10-19 only
-claude-studio produce-video --script script.txt --scene-start 10 --scene-limit 10
-```
-
-### Audio Generation
-
-#### `--generate-audio / --no-generate-audio`
-Generate TTS audio for each segment (default: True).
-
-Audio generation uses:
-- ElevenLabs (preferred, if API key available)
-- OpenAI TTS (fallback, HD quality)
-- Segment-by-segment to avoid length limits
-
-#### `--voice-id TEXT`
-Voice ID for TTS generation (default: "pFZP5JQG7iQjIQuC4Bku" - Lily voice).
-
-**ElevenLabs Voice IDs:**
-- `pFZP5JQG7iQjIQuC4Bku` - Lily (warm, engaging)
-- `21m00Tcm4TlvDq8ikWAM` - Rachel (clear, professional)
-- `pNInz6obpgDQGcFmaJgB` - Adam (deep, authoritative)
-
-**OpenAI Voices:**
-- `alloy`, `echo`, `fable`, `onyx`, `nova`, `shimmer`
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `-o`, `--output` | path | `output.mp4` | Output video path |
+| `--live/--mock` | flag | mock | Use real APIs (live) or mock generation |
+| `--style` | choice | `technical` | Visual style: `technical`, `educational`, `documentary` |
+| `--kb` | string | | Knowledge base project name (for figure access) |
+| `-b`, `--budget` | choice | | Budget tier: `micro`, `low`, `medium`, `high`, `full` |
+| `--show-tiers` | flag | | Show cost comparison for all budget tiers, then exit |
+| `-l`, `--limit` | int | | Limit to N scenes (for incremental production) |
+| `--start` | int | 0 | Start from scene index (0-based) |
+| `--audio/--no-audio` | flag | audio | Generate TTS audio narration for each scene |
+| `--voice` | string | `lily` | ElevenLabs voice name or voice_id |
 
 ## Examples
 
-### Basic Usage
-
 ```bash
-# Generate from training data (mock mode)
-claude-studio produce-video --from-training latest
+# Generate from training (mock mode)
+cs produce-video --from-training latest
 
-# Generate from script file with live providers
-claude-studio produce-video --script my_transcript.txt --live
+# Script-to-video with live providers
+cs produce-video --script transcript.txt --live
 
-# Use knowledge base figures
-claude-studio produce-video --script script.txt --live --kb-project research-2024
+# With KB figures and budget control
+cs produce-video --script script.txt --live --kb my-research --budget medium
+
+# Show cost estimates
+cs produce-video --script script.txt --show-tiers
+
+# Process only first 5 scenes
+cs produce-video --script script.txt --live --limit 5
+
+# Process scenes 10-19
+cs produce-video --script script.txt --live --start 10 --limit 10
+
+# Skip audio, documentary style
+cs produce-video --script script.txt --live --no-audio --style documentary
+
+# Custom voice
+cs produce-video --script script.txt --live --voice adam
 ```
 
-### Budget Control
+## TTS Provider Fallback
 
-```bash
-# Show cost estimates for different tiers
-claude-studio produce-video --script script.txt --show-tiers
+Audio generation tries ElevenLabs first, then falls back to OpenAI TTS (tts-1-hd, "onyx" voice). Set `TTS_PROVIDER=openai` to force OpenAI TTS (useful when ElevenLabs quota is exhausted — ~20x cheaper).
 
-# Use specific budget tier
-claude-studio produce-video --script script.txt --live --budget medium
+## Budget Tiers
 
-# High-quality production with animations
-claude-studio produce-video --script script.txt --live --budget high --kb-project figures
-```
+Use `--show-tiers` to see a detailed cost breakdown for your script. Generally:
 
-### Content Filtering
+| Tier | Cost Range | Description |
+|------|-----------|-------------|
+| `micro` | $0–3 | Text overlays, minimal images |
+| `low` | $3–8 | Basic DALL-E images, shared assets |
+| `medium` | $8–20 | Full DALL-E + some animations |
+| `high` | $20–50 | Premium generation with Luma animations |
+| `full` | $50+ | Maximum quality, all animations |
 
-```bash
-# Test with first 5 scenes only
-claude-studio produce-video --script script.txt --scene-limit 5 --live
-
-# Process specific range (scenes 10-19)
-claude-studio produce-video --script script.txt --scene-start 10 --scene-limit 10 --live
-
-# Different narrative styles
-claude-studio produce-video --script script.txt --style podcast --live
-claude-studio produce-video --script script.txt --style documentary --live
-```
-
-### Audio Options
-
-```bash
-# Skip audio generation (visual only)
-claude-studio produce-video --script script.txt --no-generate-audio --live
-
-# Use specific voice
-claude-studio produce-video --script script.txt --voice-id "21m00Tcm4TlvDq8ikWAM" --live
-
-# Custom output directory
-claude-studio produce-video --script script.txt --output ./my_video_project/ --live
-```
-
-## Production Pipeline
-
-### Phase 1: Content Analysis
-
-1. **Script Parsing**
-   - Segment text into meaningful chunks
-   - Extract key concepts and technical terms
-   - Identify figure references and visual opportunities
-
-2. **Knowledge Base Integration** (if `--kb-project` specified)
-   - Load available figures from KB project
-   - Match figures to segments based on content similarity
-   - Build figure-to-segment mapping for visual planning
-
-### Phase 2: Visual Planning
-
-1. **Budget Allocation**
-   - Analyze script complexity and length
-   - Distribute budget across scenes based on importance
-   - Determine asset generation strategy per scene
-
-2. **Asset Source Selection**
-   - **KB Figures**: Use extracted PDF figures as seeds
-   - **DALL-E Generation**: Create custom images for primary scenes
-   - **Web Images**: Source from Wikimedia Commons
-   - **Shared Assets**: Reuse images across similar scenes
-   - **Text Overlays**: Pure text for transitional content
-
-3. **Animation Planning**
-   - Ken Burns effects for static images
-   - Luma AI animations for dynamic content
-   - Budget-conscious animation allocation
-
-### Phase 3: Asset Generation
-
-1. **Image Generation**
-   - DALL-E 3 HD (1792x1024) for custom visuals
-   - Wikimedia Commons for educational content
-   - KB figure copying and processing
-
-2. **Audio Generation** (if enabled)
-   - Text-to-speech using ElevenLabs or OpenAI
-   - Segment-by-segment processing for quality
-   - Actual duration recording for timing sync
-
-3. **Content Library Management**
-   - Asset registration with metadata
-   - Status tracking (draft → review → approved)
-   - Reuse detection and optimization
-
-### Phase 4: Assembly Preparation
-
-1. **Timing Calculation**
-   - Audio-driven segment durations
-   - Figure sync point determination
-   - Transition planning between segments
-
-2. **Assembly Manifest Creation**
-   - Detailed instructions for video assembly
-   - Asset-to-segment mapping
-   - Display mode specifications
-
-## Budget Tiers Explained
-
-### Micro Tier ($0-3)
-- Text overlays with simple backgrounds
-- Minimal image generation
-- Shared assets across multiple segments
-- Basic transitions
-
-**Best for:** Short explanations, text-heavy content
-
-### Low Tier ($3-8)
-- Basic DALL-E images for key concepts
-- Some web images from Wikimedia
-- Shared assets for similar content
-- Ken Burns effects on images
-
-**Best for:** Educational content, documentation
-
-### Medium Tier ($8-20)
-- Full DALL-E generation for primary scenes
-- KB figures integrated as seeds
-- Some Luma AI animations
-- Enhanced visual variety
-
-**Best for:** Engaging tutorials, presentations
-
-### High Tier ($20-50)
-- Premium image generation
-- Extensive Luma AI animations
-- Multiple variations for quality
-- Professional-grade visuals
-
-**Best for:** Marketing content, high-production videos
-
-### Full Tier ($50+)
-- Maximum quality assets
-- All scenes get premium treatment
-- Extensive animation and effects
-- Multiple generation attempts
-
-**Best for:** Commercial productions, flagship content
-
-## Knowledge Base Integration
-
-### KB Project Setup
-
-```bash
-# Create KB project
-claude-studio kb create my-project
-
-# Ingest PDF documents
-claude-studio kb ingest my-project --pdf document.pdf --extract-figures
-
-# List available figures
-claude-studio kb list my-project --figures
-```
-
-### Figure Matching
-
-The system automatically matches KB figures to script segments based on:
-
-1. **Keyword Matching**: Technical terms and concepts
-2. **Context Analysis**: Semantic similarity
-3. **Figure Captions**: Content from PDF extraction
-4. **Manual References**: Explicit figure mentions in script
-
-### Figure Usage
-
-Matched figures are used as:
-- **Seed Images**: For Luma AI video generation
-- **Static Visuals**: With Ken Burns effects
-- **Background Elements**: For text overlays
-
-## Output Structure
-
-```
-artifacts/video_production/<timestamp>/
-├── structured_script.json     # Parsed script segments
-├── content_library.json       # Asset registry
-├── assembly_manifest.json     # Assembly instructions
-├── audio/                     # Generated audio files
-│   ├── audio_001.mp3
-│   ├── audio_002.mp3
-│   └── ...
-├── images/                    # Generated/sourced images  
-│   ├── scene_001.png
-│   ├── scene_002.png
-│   └── ...
-├── videos/                    # Generated video clips (if animated)
-│   ├── scene_001_luma.mp4
-│   └── ...
-└── assembly/                  # Final assembly output
-    ├── segments/              # Individual video segments
-    ├── rough_cut.mp4         # Assembled video
-    └── assembly_manifest.json
-```
-
-## Asset Sources Summary
-
-Generated assets come from multiple sources:
-
-### KB Figures (Free)
-- Extracted from PDF documents
-- High-quality academic/technical figures
-- Perfect for educational content
-- Used as seeds for animation
-
-### DALL-E Images (~$0.08 each)
-- Custom AI-generated images
-- HD quality (1792x1024)
-- Tailored to specific content
-- Primary visual source
-
-### Web Images (Free)
-- Wikimedia Commons sourcing
-- Educational and reference images
-- Automatic license compliance
-- Fallback for common concepts
-
-### Shared Assets (Free)
-- Reuse across similar segments
-- Budget optimization strategy
-- Maintains visual consistency
-- Reduces generation costs
-
-### Text Overlays (Free)
-- Pure text on styled backgrounds
-- Transitional content
-- Quote presentations
-- Zero-cost option
-
-## Integration with Assembly
-
-The produce-video command prepares content for the `assemble` command:
+## Integration
 
 ```bash
 # 1. Generate assets
-claude-studio produce-video --script script.txt --live --kb-project my-kb
+cs produce-video --script script.txt --live --kb my-kb --budget medium
 
 # 2. Assemble rough cut
-claude-studio assemble <output_directory>
+cs assemble <run_id>
 
-# 3. Review and approve assets
-claude-studio assets list <output_directory>
-claude-studio assets approve <output_directory> --image all --audio all
-
-# 4. Final assembly
-claude-studio assets build <output_directory>
+# 3. Upload to YouTube
+cs upload youtube output.mp4 --title "My Video"
 ```
-
-## Performance Tips
-
-### Development
-- Use mock mode for script testing
-- Set `--scene-limit 3` for quick iterations
-- Test different budget tiers with `--show-tiers`
-
-### Production
-- Create KB projects for figure reuse
-- Use appropriate budget tiers for content type
-- Generate audio in segments for better quality
-
-### Optimization
-- Reuse KB figures across multiple videos
-- Share assets between similar segments
-- Batch process multiple scripts with same KB
-
-## Common Workflows
-
-### Academic Content
-```bash
-# 1. Create KB from research papers
-claude-studio kb create research-2024
-claude-studio kb ingest research-2024 --pdf paper1.pdf paper2.pdf
-
-# 2. Generate educational video
-claude-studio produce-video --script lecture_script.txt \
-  --kb-project research-2024 --style educational --budget medium --live
-
-# 3. Assemble and refine
-claude-studio assemble <output_dir>
-```
-
-### Podcast to Video
-```bash
-# 1. Use training pipeline for transcript analysis  
-claude-studio training run --transcript podcast_transcript.txt
-
-# 2. Generate with podcast style
-claude-studio produce-video --from-training latest \
-  --style podcast --budget high --live
-
-# 3. Review and publish
-claude-studio assets list <output_dir>
-claude-studio upload youtube <output_dir>/assembly/rough_cut.mp4
-```
-
-### Technical Documentation
-```bash
-# 1. Process documentation
-claude-studio produce-video --script tech_doc.md \
-  --style visual_storyboard --budget low --live
-
-# 2. Focus on key sections
-claude-studio produce-video --script tech_doc.md \
-  --scene-start 5 --scene-limit 10 --budget medium --live
-```
-
-## Error Handling
-
-### Input Issues
-```bash
-# Training trial not found
-Error: Trial not found: 20260207_999999
-# Solution: Use claude-studio training list to see available trials
-
-# Script file missing
-Error: Script file not found: script.txt
-# Solution: Verify file path and permissions
-```
-
-### API Configuration
-```bash
-# Missing TTS provider
-Error: No TTS provider available - set ELEVENLABS_API_KEY or OPENAI_API_KEY
-# Solution: Configure API keys via secrets command
-```
-
-### KB Integration
-```bash
-# KB project not found  
-Error: KB project not found: my-project
-# Solution: Create KB project first with claude-studio kb create
-```
-
-### Generation Failures
-```bash
-# DALL-E quota exceeded
-Warning: DALL-E generation failed, using web image fallback
-# Solution: Wait for quota reset or use lower budget tier
-```
-
-## Environment Variables
-
-- `TTS_PROVIDER` - Force TTS provider (`openai` to skip ElevenLabs)
-- `ELEVENLABS_API_KEY` - ElevenLabs voice synthesis
-- `OPENAI_API_KEY` - OpenAI TTS and DALL-E
-- `ANTHROPIC_API_KEY` - Claude for content analysis
-
-## Version History
-
-- **0.6.0**: Unified Production Architecture with content library
-- **0.5.x**: Knowledge base integration and figure matching
-- **0.4.x**: Basic transcript-to-video pipeline

--- a/docs/cli/produce-video.md
+++ b/docs/cli/produce-video.md
@@ -1,0 +1,516 @@
+# produce-video - Explainer Videos from Scripts
+
+The `produce-video` command generates explainer videos from podcast scripts and documents using the Unified Production Architecture. This command creates transcript-led video production with figure synchronization and budget-aware asset generation.
+
+## Synopsis
+
+```bash
+claude-studio produce-video [--from-training TRIAL_ID | --script PATH] [OPTIONS]
+```
+
+## Description
+
+The produce-video command specializes in creating educational and explanatory videos from structured content. It supports:
+
+- Training-based production from analyzed documents
+- Direct script-to-video conversion
+- Knowledge base figure integration
+- Budget-aware asset allocation
+- Multi-tier cost optimization
+
+## Input Sources (Required)
+
+Choose one input source:
+
+### `--from-training TRIAL_ID`
+Load content from a training trial.
+
+Training trials are created by the `training run` command and contain:
+- Aligned transcript segments
+- Knowledge graphs with figure references  
+- Style and structure profiles
+- Pre-analyzed content hierarchy
+
+**Examples:**
+- `--from-training latest` - Use most recent training
+- `--from-training 20260207_143022` - Specific trial ID
+
+### `--script PATH`
+Generate directly from a script file.
+
+Script files should contain well-structured text with natural paragraph breaks (double newlines). This mode bypasses training requirements but provides less sophisticated content analysis.
+
+**Examples:**
+- `--script my_script.txt`
+- `--script ./content/podcast_transcript.md`
+
+## Options
+
+### Core Options
+
+#### `--output PATH`
+Output directory path (default: `artifacts/video_production/<timestamp>`).
+
+#### `--live`
+Use live API providers (costs money!). 
+
+When not specified, runs in mock mode with simulated assets.
+
+#### `--style CHOICE`
+Narrative style for video production.
+
+**Choices:**
+- `visual_storyboard` - Visual-focused narrative (default)
+- `podcast` - Rich NotebookLM-style narration
+- `educational` - Educational lecture format  
+- `documentary` - Documentary style
+
+### Knowledge Base Integration
+
+#### `--kb-project TEXT`
+Knowledge base project name for figure integration.
+
+Enables automatic figure matching and seeding for video generation. The KB project should be created and populated using the `kb` commands.
+
+**Example:**
+```bash
+# First create and populate KB
+claude-studio kb create my-research
+claude-studio kb ingest my-research --pdf research.pdf
+
+# Then use in video production
+claude-studio produce-video --script script.txt --kb-project my-research
+```
+
+### Budget Control
+
+#### `--budget CHOICE`
+Budget tier for asset generation.
+
+**Choices:**
+- `micro` - Text overlays and minimal images
+- `low` - Basic DALL-E images, shared assets
+- `medium` - Full DALL-E + some animations
+- `high` - Premium generation with Luma animations  
+- `full` - Maximum quality, all animations
+
+**Budget Impact:**
+- Higher tiers enable more DALL-E generations
+- Animation allocation increases with budget
+- Figure seeding optimizes across all tiers
+
+#### `--show-tiers`
+Display budget tier comparison table and exit.
+
+Shows detailed cost breakdown for each tier based on script analysis.
+
+### Content Filtering
+
+#### `--scene-limit INTEGER`
+Maximum number of scenes to process.
+
+Useful for testing or partial generation. Processes scenes from `--scene-start` up to the limit.
+
+#### `--scene-start INTEGER`
+Starting scene index (default: 0).
+
+Combined with `--scene-limit` allows processing specific scene ranges.
+
+**Example:**
+```bash
+# Process scenes 10-19 only
+claude-studio produce-video --script script.txt --scene-start 10 --scene-limit 10
+```
+
+### Audio Generation
+
+#### `--generate-audio / --no-generate-audio`
+Generate TTS audio for each segment (default: True).
+
+Audio generation uses:
+- ElevenLabs (preferred, if API key available)
+- OpenAI TTS (fallback, HD quality)
+- Segment-by-segment to avoid length limits
+
+#### `--voice-id TEXT`
+Voice ID for TTS generation (default: "pFZP5JQG7iQjIQuC4Bku" - Lily voice).
+
+**ElevenLabs Voice IDs:**
+- `pFZP5JQG7iQjIQuC4Bku` - Lily (warm, engaging)
+- `21m00Tcm4TlvDq8ikWAM` - Rachel (clear, professional)
+- `pNInz6obpgDQGcFmaJgB` - Adam (deep, authoritative)
+
+**OpenAI Voices:**
+- `alloy`, `echo`, `fable`, `onyx`, `nova`, `shimmer`
+
+## Examples
+
+### Basic Usage
+
+```bash
+# Generate from training data (mock mode)
+claude-studio produce-video --from-training latest
+
+# Generate from script file with live providers
+claude-studio produce-video --script my_transcript.txt --live
+
+# Use knowledge base figures
+claude-studio produce-video --script script.txt --live --kb-project research-2024
+```
+
+### Budget Control
+
+```bash
+# Show cost estimates for different tiers
+claude-studio produce-video --script script.txt --show-tiers
+
+# Use specific budget tier
+claude-studio produce-video --script script.txt --live --budget medium
+
+# High-quality production with animations
+claude-studio produce-video --script script.txt --live --budget high --kb-project figures
+```
+
+### Content Filtering
+
+```bash
+# Test with first 5 scenes only
+claude-studio produce-video --script script.txt --scene-limit 5 --live
+
+# Process specific range (scenes 10-19)
+claude-studio produce-video --script script.txt --scene-start 10 --scene-limit 10 --live
+
+# Different narrative styles
+claude-studio produce-video --script script.txt --style podcast --live
+claude-studio produce-video --script script.txt --style documentary --live
+```
+
+### Audio Options
+
+```bash
+# Skip audio generation (visual only)
+claude-studio produce-video --script script.txt --no-generate-audio --live
+
+# Use specific voice
+claude-studio produce-video --script script.txt --voice-id "21m00Tcm4TlvDq8ikWAM" --live
+
+# Custom output directory
+claude-studio produce-video --script script.txt --output ./my_video_project/ --live
+```
+
+## Production Pipeline
+
+### Phase 1: Content Analysis
+
+1. **Script Parsing**
+   - Segment text into meaningful chunks
+   - Extract key concepts and technical terms
+   - Identify figure references and visual opportunities
+
+2. **Knowledge Base Integration** (if `--kb-project` specified)
+   - Load available figures from KB project
+   - Match figures to segments based on content similarity
+   - Build figure-to-segment mapping for visual planning
+
+### Phase 2: Visual Planning
+
+1. **Budget Allocation**
+   - Analyze script complexity and length
+   - Distribute budget across scenes based on importance
+   - Determine asset generation strategy per scene
+
+2. **Asset Source Selection**
+   - **KB Figures**: Use extracted PDF figures as seeds
+   - **DALL-E Generation**: Create custom images for primary scenes
+   - **Web Images**: Source from Wikimedia Commons
+   - **Shared Assets**: Reuse images across similar scenes
+   - **Text Overlays**: Pure text for transitional content
+
+3. **Animation Planning**
+   - Ken Burns effects for static images
+   - Luma AI animations for dynamic content
+   - Budget-conscious animation allocation
+
+### Phase 3: Asset Generation
+
+1. **Image Generation**
+   - DALL-E 3 HD (1792x1024) for custom visuals
+   - Wikimedia Commons for educational content
+   - KB figure copying and processing
+
+2. **Audio Generation** (if enabled)
+   - Text-to-speech using ElevenLabs or OpenAI
+   - Segment-by-segment processing for quality
+   - Actual duration recording for timing sync
+
+3. **Content Library Management**
+   - Asset registration with metadata
+   - Status tracking (draft → review → approved)
+   - Reuse detection and optimization
+
+### Phase 4: Assembly Preparation
+
+1. **Timing Calculation**
+   - Audio-driven segment durations
+   - Figure sync point determination
+   - Transition planning between segments
+
+2. **Assembly Manifest Creation**
+   - Detailed instructions for video assembly
+   - Asset-to-segment mapping
+   - Display mode specifications
+
+## Budget Tiers Explained
+
+### Micro Tier ($0-3)
+- Text overlays with simple backgrounds
+- Minimal image generation
+- Shared assets across multiple segments
+- Basic transitions
+
+**Best for:** Short explanations, text-heavy content
+
+### Low Tier ($3-8)
+- Basic DALL-E images for key concepts
+- Some web images from Wikimedia
+- Shared assets for similar content
+- Ken Burns effects on images
+
+**Best for:** Educational content, documentation
+
+### Medium Tier ($8-20)
+- Full DALL-E generation for primary scenes
+- KB figures integrated as seeds
+- Some Luma AI animations
+- Enhanced visual variety
+
+**Best for:** Engaging tutorials, presentations
+
+### High Tier ($20-50)
+- Premium image generation
+- Extensive Luma AI animations
+- Multiple variations for quality
+- Professional-grade visuals
+
+**Best for:** Marketing content, high-production videos
+
+### Full Tier ($50+)
+- Maximum quality assets
+- All scenes get premium treatment
+- Extensive animation and effects
+- Multiple generation attempts
+
+**Best for:** Commercial productions, flagship content
+
+## Knowledge Base Integration
+
+### KB Project Setup
+
+```bash
+# Create KB project
+claude-studio kb create my-project
+
+# Ingest PDF documents
+claude-studio kb ingest my-project --pdf document.pdf --extract-figures
+
+# List available figures
+claude-studio kb list my-project --figures
+```
+
+### Figure Matching
+
+The system automatically matches KB figures to script segments based on:
+
+1. **Keyword Matching**: Technical terms and concepts
+2. **Context Analysis**: Semantic similarity
+3. **Figure Captions**: Content from PDF extraction
+4. **Manual References**: Explicit figure mentions in script
+
+### Figure Usage
+
+Matched figures are used as:
+- **Seed Images**: For Luma AI video generation
+- **Static Visuals**: With Ken Burns effects
+- **Background Elements**: For text overlays
+
+## Output Structure
+
+```
+artifacts/video_production/<timestamp>/
+├── structured_script.json     # Parsed script segments
+├── content_library.json       # Asset registry
+├── assembly_manifest.json     # Assembly instructions
+├── audio/                     # Generated audio files
+│   ├── audio_001.mp3
+│   ├── audio_002.mp3
+│   └── ...
+├── images/                    # Generated/sourced images  
+│   ├── scene_001.png
+│   ├── scene_002.png
+│   └── ...
+├── videos/                    # Generated video clips (if animated)
+│   ├── scene_001_luma.mp4
+│   └── ...
+└── assembly/                  # Final assembly output
+    ├── segments/              # Individual video segments
+    ├── rough_cut.mp4         # Assembled video
+    └── assembly_manifest.json
+```
+
+## Asset Sources Summary
+
+Generated assets come from multiple sources:
+
+### KB Figures (Free)
+- Extracted from PDF documents
+- High-quality academic/technical figures
+- Perfect for educational content
+- Used as seeds for animation
+
+### DALL-E Images (~$0.08 each)
+- Custom AI-generated images
+- HD quality (1792x1024)
+- Tailored to specific content
+- Primary visual source
+
+### Web Images (Free)
+- Wikimedia Commons sourcing
+- Educational and reference images
+- Automatic license compliance
+- Fallback for common concepts
+
+### Shared Assets (Free)
+- Reuse across similar segments
+- Budget optimization strategy
+- Maintains visual consistency
+- Reduces generation costs
+
+### Text Overlays (Free)
+- Pure text on styled backgrounds
+- Transitional content
+- Quote presentations
+- Zero-cost option
+
+## Integration with Assembly
+
+The produce-video command prepares content for the `assemble` command:
+
+```bash
+# 1. Generate assets
+claude-studio produce-video --script script.txt --live --kb-project my-kb
+
+# 2. Assemble rough cut
+claude-studio assemble <output_directory>
+
+# 3. Review and approve assets
+claude-studio assets list <output_directory>
+claude-studio assets approve <output_directory> --image all --audio all
+
+# 4. Final assembly
+claude-studio assets build <output_directory>
+```
+
+## Performance Tips
+
+### Development
+- Use mock mode for script testing
+- Set `--scene-limit 3` for quick iterations
+- Test different budget tiers with `--show-tiers`
+
+### Production
+- Create KB projects for figure reuse
+- Use appropriate budget tiers for content type
+- Generate audio in segments for better quality
+
+### Optimization
+- Reuse KB figures across multiple videos
+- Share assets between similar segments
+- Batch process multiple scripts with same KB
+
+## Common Workflows
+
+### Academic Content
+```bash
+# 1. Create KB from research papers
+claude-studio kb create research-2024
+claude-studio kb ingest research-2024 --pdf paper1.pdf paper2.pdf
+
+# 2. Generate educational video
+claude-studio produce-video --script lecture_script.txt \
+  --kb-project research-2024 --style educational --budget medium --live
+
+# 3. Assemble and refine
+claude-studio assemble <output_dir>
+```
+
+### Podcast to Video
+```bash
+# 1. Use training pipeline for transcript analysis  
+claude-studio training run --transcript podcast_transcript.txt
+
+# 2. Generate with podcast style
+claude-studio produce-video --from-training latest \
+  --style podcast --budget high --live
+
+# 3. Review and publish
+claude-studio assets list <output_dir>
+claude-studio upload youtube <output_dir>/assembly/rough_cut.mp4
+```
+
+### Technical Documentation
+```bash
+# 1. Process documentation
+claude-studio produce-video --script tech_doc.md \
+  --style visual_storyboard --budget low --live
+
+# 2. Focus on key sections
+claude-studio produce-video --script tech_doc.md \
+  --scene-start 5 --scene-limit 10 --budget medium --live
+```
+
+## Error Handling
+
+### Input Issues
+```bash
+# Training trial not found
+Error: Trial not found: 20260207_999999
+# Solution: Use claude-studio training list to see available trials
+
+# Script file missing
+Error: Script file not found: script.txt
+# Solution: Verify file path and permissions
+```
+
+### API Configuration
+```bash
+# Missing TTS provider
+Error: No TTS provider available - set ELEVENLABS_API_KEY or OPENAI_API_KEY
+# Solution: Configure API keys via secrets command
+```
+
+### KB Integration
+```bash
+# KB project not found  
+Error: KB project not found: my-project
+# Solution: Create KB project first with claude-studio kb create
+```
+
+### Generation Failures
+```bash
+# DALL-E quota exceeded
+Warning: DALL-E generation failed, using web image fallback
+# Solution: Wait for quota reset or use lower budget tier
+```
+
+## Environment Variables
+
+- `TTS_PROVIDER` - Force TTS provider (`openai` to skip ElevenLabs)
+- `ELEVENLABS_API_KEY` - ElevenLabs voice synthesis
+- `OPENAI_API_KEY` - OpenAI TTS and DALL-E
+- `ANTHROPIC_API_KEY` - Claude for content analysis
+
+## Version History
+
+- **0.6.0**: Unified Production Architecture with content library
+- **0.5.x**: Knowledge base integration and figure matching
+- **0.4.x**: Basic transcript-to-video pipeline

--- a/docs/cli/produce.md
+++ b/docs/cli/produce.md
@@ -1,0 +1,439 @@
+# produce - Full Video Production Pipeline
+
+The `produce` command runs the complete AI video production pipeline with multi-agent orchestration. This is the main entry point for creating videos from concept descriptions.
+
+## Synopsis
+
+```bash
+claude-studio produce -c CONCEPT [OPTIONS]
+```
+
+## Description
+
+The produce command demonstrates sophisticated agent patterns including:
+- Sequential planning stages (Producer → ScriptWriter)
+- Parallel asset generation (Video + Audio via Strands)
+- Quality evaluation pipeline (QA → Critic → Editor)
+
+## Required Arguments
+
+### `--concept, -c TEXT`
+Video concept description (required).
+
+**Examples:**
+- `"Logo reveal for TechCorp"`
+- `"Product demo for mobile app"`
+- `"Tutorial on machine learning basics"`
+
+## Options
+
+### Core Options
+
+#### `--budget, -b FLOAT`
+Total budget in USD (default: 10.0).
+
+Controls production scale and provider usage. Higher budgets enable more variations and premium providers.
+
+#### `--duration, -d FLOAT` 
+Target video duration in seconds (default: 30.0).
+
+Influences scene count and pacing. Typical ranges:
+- 5-15s: Logo/brand videos
+- 30-60s: Product demos
+- 60-300s: Tutorials/explanations
+
+#### `--provider, -p CHOICE`
+Video provider to use.
+
+**Choices:**
+- `luma` - Luma AI (recommended, text/image to video)
+- `runway` - Runway ML (image to video)  
+- `mock` - Mock provider (development/testing)
+
+**Default:** `luma`
+
+### Execution Mode
+
+#### `--live`
+Use live API providers (costs real money!).
+
+When specified, uses actual API providers. **Warning:** Generates real costs.
+
+#### `--mock` 
+Use mock providers (default).
+
+Safe development mode with simulated responses and no API costs.
+
+### Production Options
+
+#### `--audio-tier CHOICE`
+Audio production tier.
+
+**Choices:**
+- `none` - No audio generation (default)
+- `music_only` - Background music only
+- `simple_overlay` - Basic voiceover + music
+- `time_synced` - Synchronized audio with video timing
+
+#### `--variations, -v INTEGER`
+Number of video variations per scene (default: 1).
+
+Higher values provide more options but increase cost and generation time.
+
+#### `--timeout INTEGER`
+Video generation timeout in seconds (default: 600).
+
+Increase for busy provider queues or complex generations.
+
+### Advanced Options
+
+#### `--seed-assets, -s PATH`
+Directory containing seed images/assets (PNG/JPG).
+
+Provides reference images for video generation, improving consistency and relevance.
+
+#### `--execution-strategy, -e CHOICE`
+Scene execution strategy for continuity.
+
+**Choices:**
+- `auto` - Automatically detect from script (default)
+- `all_parallel` - Generate all scenes in parallel (fastest)
+- `all_sequential` - Generate scenes sequentially (best continuity)
+- `manual` - Use manual groups from script
+
+#### `--style CHOICE`
+Narrative style.
+
+**Choices:**
+- `visual_storyboard` - Visual-focused narrative (default)
+- `podcast` - Rich NotebookLM-style narration
+- `educational` - Educational lecture format
+- `documentary` - Documentary style
+
+#### `--mode CHOICE`
+Production mode.
+
+**Choices:**
+- `video-led` - Video determines timing (default)
+- `audio-led` - Audio determines timing
+
+### Output Options
+
+#### `--output-dir, -o PATH`
+Output directory.
+
+**Default:** `artifacts/runs/<run_id>`
+
+#### `--run-id TEXT`
+Custom run ID.
+
+**Default:** Auto-generated timestamp (`YYYYMMDD_HHMMSS`)
+
+### Display Options
+
+#### `--verbose, -V`
+Show full artifacts without truncation.
+
+Displays complete scene descriptions, prompts, and evaluation details.
+
+#### `--theme, -t TEXT`
+Color theme.
+
+**Choices:** `default`, `ocean`, `sunset`, `matrix`, `pro`, `neon`, `mono`
+
+#### `--json`
+Output results as JSON.
+
+Suppresses rich formatting and returns structured data.
+
+#### `--debug`
+Enable debug output.
+
+Shows detailed error traces and internal processing information.
+
+## Examples
+
+### Basic Usage
+
+```bash
+# Quick 5-second demo with mock providers
+claude-studio produce -c "Logo reveal for TechCorp" -d 5 --mock
+
+# Live production with Luma (costs money)
+claude-studio produce -c "Product demo for mobile app" -b 15 -d 30 --live -p luma
+
+# Full production with audio
+claude-studio produce -c "Tutorial video" -b 50 -d 60 --audio-tier simple_overlay --live
+```
+
+### Advanced Usage
+
+```bash
+# Use seed images for consistent branding
+claude-studio produce -c "Product showcase" --live -s ./brand_assets/
+
+# Generate multiple variations
+claude-studio produce -c "Marketing video" -b 30 -v 3 --live
+
+# Extended timeout for complex scenes
+claude-studio produce -c "Complex animation" --live --timeout 900
+
+# Podcast-style narration
+claude-studio produce -c "Explain quantum computing" --style podcast --audio-tier time_synced
+
+# Audio-led production (audio timing drives video)
+claude-studio produce -c "Music video concept" --mode audio-led --audio-tier time_synced
+```
+
+### Output Control
+
+```bash
+# Custom output directory
+claude-studio produce -c "test" --mock -o ./my_production/
+
+# Custom run ID
+claude-studio produce -c "test" --mock --run-id my_custom_run
+
+# JSON output for scripting
+claude-studio produce -c "test" --mock --json > result.json
+
+# Different color theme
+claude-studio produce -c "test" --mock --theme matrix
+
+# Verbose output with full details
+claude-studio produce -c "test" --mock --verbose
+```
+
+## Pipeline Stages
+
+### Stage 1: Planning (Sequential)
+
+1. **ProducerAgent** analyzes concept and creates pilot strategies
+   - Budget allocation across production tiers
+   - Provider knowledge from long-term memory
+   - Risk assessment and feasibility analysis
+
+2. **ScriptWriterAgent** generates scene breakdown
+   - Optimal scene count based on duration
+   - Visual elements and transitions
+   - Prompt optimization for selected provider
+
+**Output:** Scene specifications and production plan
+
+### Stage 2: Asset Generation (Parallel via Strands)
+
+1. **VideoGeneratorAgent** creates video content
+   - Uses execution strategy for continuity
+   - Parallel or sequential generation based on dependencies
+   - Seed asset integration when provided
+
+2. **AudioGeneratorAgent** generates voiceover and music (if enabled)
+   - Text-to-speech with selected voice
+   - Background music matching video tone
+   - Timing synchronization with video duration
+
+**Output:** Video clips and audio tracks
+
+### Stage 3: Evaluation (Sequential)
+
+1. **QAVerifierAgent** analyzes video quality
+   - Visual accuracy and coherence
+   - Style consistency across scenes
+   - Technical quality assessment
+   - Narrative fit with original concept
+
+2. **CriticAgent** scores production quality
+   - Overall production evaluation
+   - Budget efficiency analysis
+   - Approval/rejection recommendation
+   - Provider performance learning
+
+3. **EditorAgent** creates Edit Decision Lists (EDLs)
+   - Multiple edit candidate generation
+   - Transition selection and timing
+   - Text overlay positioning
+   - Final assembly instructions
+
+**Output:** Quality scores, approval status, and EDL
+
+### Stage 4: Rendering
+
+1. **AudioMixer** combines video and audio
+   - Fit mode based on production mode
+   - Volume balancing and normalization
+   - Scene concatenation
+
+2. **FFmpegRenderer** creates final video
+   - Transition effects application
+   - Text overlay rendering
+   - Format optimization
+
+**Output:** Final rendered video
+
+## Output Structure
+
+Production runs create organized directory structures:
+
+```
+artifacts/runs/<run_id>/
+├── metadata.json           # Run metadata and costs
+├── scenes/                 # Scene specifications
+│   ├── scene_001.json
+│   ├── scene_002.json
+│   └── ...
+├── videos/                 # Generated video clips
+│   ├── scene_001_v0.mp4
+│   ├── scene_002_v0.mp4
+│   └── ...
+├── audio/                  # Audio files (if enabled)
+│   ├── scene_001_voice.mp3
+│   └── background_music.mp3
+├── edl/                    # Edit Decision Lists
+│   ├── edit_candidates.json
+│   ├── recommended_cut.json
+│   └── ...
+├── renders/                # Final rendered videos
+│   └── final_video.mp4
+├── mixed/                  # Video+audio combinations
+│   └── scene_001_mixed.mp4
+└── final_output.mp4        # Complete final video
+```
+
+## Budget and Cost Management
+
+The produce command includes sophisticated budget management:
+
+### Production Tiers
+
+Based on budget allocation:
+
+- **Micro** ($0-5): Single scenes, basic quality
+- **Low** ($5-15): Multiple scenes, standard quality
+- **Medium** ($15-50): Enhanced quality, multiple variations
+- **High** ($50-100): Premium quality, extensive variations
+- **Full** ($100+): Maximum quality, comprehensive production
+
+### Cost Tracking
+
+Costs are tracked throughout production:
+
+```json
+{
+  "costs": {
+    "video": 2.50,
+    "audio": 0.15,
+    "total": 2.65
+  },
+  "budget_allocated": 10.00,
+  "budget_spent": 2.65
+}
+```
+
+## Memory and Learning
+
+The produce command leverages long-term memory for optimization:
+
+### Provider Learning
+- Successful prompt patterns
+- Quality score trends  
+- Cost optimization strategies
+- Common failure modes
+
+### Pattern Recognition
+- Scene types that work well
+- Optimal duration ranges
+- Effective transitions
+- Audio-video synchronization
+
+## Error Handling
+
+Common issues and solutions:
+
+### API Configuration
+```bash
+# Missing API keys
+Error: LUMA_API_KEY not set (check keychain or env)
+
+# Solution
+claude-studio secrets set LUMA_API_KEY your_key
+```
+
+### Budget Constraints
+```bash
+# Insufficient budget
+Warning: Concept complexity requires $15+ budget, got $5
+
+# Solution
+claude-studio produce -c "concept" -b 20 --live
+```
+
+### Generation Failures
+```bash
+# Provider timeout
+Error: Video generation timeout after 600s
+
+# Solution  
+claude-studio produce -c "concept" --timeout 900 --live
+```
+
+### FFmpeg Issues
+```bash
+# Missing FFmpeg
+Warning: FFmpeg not installed - skipping render
+
+# Solution
+brew install ffmpeg  # macOS
+sudo apt install ffmpeg  # Ubuntu
+```
+
+## Integration with Other Commands
+
+### Resume Failed Productions
+```bash
+# If production fails, resume from checkpoint
+claude-studio resume <run_id> --live
+```
+
+### Re-render with Different Settings
+```bash
+# Use existing assets with new edit
+claude-studio render edl <run_id> -c creative_cut
+```
+
+### Upload Results
+```bash
+# Upload final video to YouTube
+claude-studio upload youtube artifacts/runs/<run_id>/final_output.mp4 \
+  -t "My Video Title"
+```
+
+### Asset Management
+```bash
+# Review and approve individual assets
+claude-studio assets list artifacts/runs/<run_id>
+claude-studio assets approve artifacts/runs/<run_id> --image all
+```
+
+## Performance Tips
+
+### Development
+- Use `--mock` flag during development
+- Start with short durations (5-10s)
+- Test concepts with single variations
+
+### Production
+- Set appropriate timeouts for complex scenes
+- Use seed assets for consistency
+- Monitor costs with budget limits
+- Utilize multiple variations for better results
+
+### Optimization
+- Reuse approved assets across runs
+- Leverage provider learning from memory
+- Batch similar productions for efficiency
+
+## Version History
+
+- **0.6.0**: Current version with unified production architecture
+- **0.5.x**: Multi-agent orchestration with Strands patterns  
+- **0.4.x**: Basic video generation pipeline

--- a/docs/cli/providers.md
+++ b/docs/cli/providers.md
@@ -1,0 +1,82 @@
+# Providers (`cs providers` / `cs provider` / `cs test-provider`)
+
+Manage, test, and onboard content providers (video, audio, image, music, storage).
+
+## Commands
+
+| Command | Description |
+|---------|-------------|
+| `providers list` | List all registered providers |
+| `providers check` | Check a provider's configuration |
+| `providers test` | Test a provider with a sample prompt |
+| `provider` | Provider onboarding and management |
+| `test-provider` | Quick single-provider validation |
+
+---
+
+## `providers list`
+
+```bash
+cs providers list
+cs providers list -c video
+cs providers list -s implemented --json
+```
+
+**Options:**
+| Option | Type | Description |
+|--------|------|-------------|
+| `-c`, `--category` | string | Filter by category: `video`, `audio`, `music`, `image`, `storage` |
+| `-s`, `--status` | choice | Filter: `all`, `implemented`, `stub` (default: all) |
+| `--json` | flag | Output as JSON |
+
+---
+
+## `providers check`
+
+Check a specific provider's configuration and API key status.
+
+```bash
+cs providers check luma
+```
+
+**Arguments:**
+- `NAME` — Provider name
+
+---
+
+## `providers test`
+
+Test a provider with a sample generation.
+
+```bash
+cs providers test luma
+cs providers test luma -p "A futuristic cityscape"
+```
+
+**Arguments:**
+- `NAME` — Provider name
+
+**Options:**
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `-p`, `--prompt` | string | "A serene mountain landscape" | Test prompt |
+
+---
+
+## `test-provider`
+
+Quick validation of a single provider (standalone command).
+
+```bash
+cs test-provider <provider_name>
+```
+
+---
+
+## `provider`
+
+Provider onboarding and management (reads docs, scaffolds integrations).
+
+```bash
+cs provider
+```

--- a/docs/cli/render.md
+++ b/docs/cli/render.md
@@ -1,0 +1,610 @@
+# render - EDL Rendering and Audio Mixing
+
+The `render` command provides video rendering capabilities including EDL (Edit Decision List) rendering from production runs and video+audio mixing for testing workflows.
+
+## Synopsis
+
+```bash
+claude-studio render COMMAND [OPTIONS]
+```
+
+## Description
+
+The render command offers two primary functions:
+
+1. **EDL Rendering**: Convert production EDLs into final videos with transitions and effects
+2. **Audio Mixing**: Combine video files with TTS-generated or existing audio tracks
+
+## Commands Overview
+
+| Command | Purpose |
+|---------|---------|
+| `edl` | Render final video from production run EDLs |
+| `mix` | Mix video with TTS audio or audio files |
+
+---
+
+## edl - Render Production EDLs
+
+Render a final video from an existing production run's Edit Decision List.
+
+### Synopsis
+
+```bash
+claude-studio render edl RUN_ID [OPTIONS]
+```
+
+### Arguments
+
+#### `RUN_ID`
+Run directory name from artifacts/runs/.
+
+**Examples:**
+- `20260107_224324` - Timestamp-based run ID
+- `my_custom_run` - Custom run directory name
+
+### Options
+
+#### `--candidate, -c TEXT`
+Specific edit candidate ID to render.
+
+**Default:** Uses recommended candidate from EDL
+
+#### `--output, -o PATH`
+Output file path for rendered video.
+
+**Default:** `<run_dir>/renders/final_video.mp4`
+
+#### `--list-candidates, -l`
+List available edit candidates and exit.
+
+Displays all available edit candidates with their properties before rendering.
+
+### Examples
+
+#### Basic EDL Rendering
+
+```bash
+# Render recommended edit candidate
+claude-studio render edl 20260107_224324
+
+# Render to specific output file
+claude-studio render edl 20260107_224324 -o my_final_video.mp4
+
+# List available candidates first
+claude-studio render edl 20260107_224324 --list-candidates
+```
+
+#### Candidate Selection
+
+```bash
+# Render specific edit candidate
+claude-studio render edl 20260107_224324 -c creative_cut
+
+# Compare different candidates
+claude-studio render edl 20260107_224324 -c standard_cut -o standard.mp4
+claude-studio render edl 20260107_224324 -c creative_cut -o creative.mp4
+```
+
+### EDL Structure
+
+EDL rendering works with Edit Decision Lists created by the Editor Agent:
+
+```json
+{
+  "edl_id": "edl_20260107_224324",
+  "recommended_candidate_id": "standard_cut",
+  "candidates": [
+    {
+      "candidate_id": "standard_cut",
+      "name": "Standard Professional Cut",
+      "style": "clean",
+      "total_duration": 45.2,
+      "estimated_quality": 85.5,
+      "decisions": [
+        {
+          "scene_id": "scene_001",
+          "video_url": "/path/to/scene_001_v0.mp4",
+          "in_point": 0.0,
+          "out_point": 8.5,
+          "start_time": 0.0,
+          "duration": 8.5,
+          "transition_in": "cut",
+          "transition_out": "dissolve",
+          "text_overlay": "Welcome",
+          "text_position": "center"
+        }
+      ]
+    }
+  ]
+}
+```
+
+### Rendering Features
+
+#### Video Processing
+- **Concatenation**: Seamlessly joins video clips
+- **Transitions**: Applies cuts, dissolves, and fades
+- **Timing**: Precise start/end point trimming
+- **Scaling**: Consistent resolution and aspect ratio
+
+#### Text Overlays
+- **Positioning**: Center, top, bottom placement options
+- **Styling**: Title, subtitle, caption text styles  
+- **Timing**: Precise overlay start and duration control
+- **Effects**: Fade-in and fade-out animations
+
+#### Audio Integration
+- **Track Mixing**: Combines multiple audio sources
+- **Volume Control**: Per-track volume adjustment
+- **Synchronization**: Perfect audio-video sync
+- **Format Support**: MP3, WAV, AAC input formats
+
+### Sample Output
+
+```bash
+claude-studio render edl 20260107_224324 --list-candidates
+
+┌─ Edit Candidates for 20260107_224324 ───────────────┐
+│ ID            │ Name              │ Style  │ Duration │ Quality │ Recommended │
+├───────────────┼───────────────────┼────────┼──────────┼─────────┼─────────────┤
+│ standard_cut  │ Standard Cut      │ clean  │ 45.2s    │ 85      │ *           │
+│ creative_cut  │ Creative Edit     │ dynamic│ 43.8s    │ 82      │             │
+│ minimal_cut   │ Minimal Approach  │ simple │ 38.5s    │ 78      │             │
+└───────────────┴───────────────────┴────────┴──────────┴─────────┴─────────────┘
+
+Rendering candidate: standard_cut
+
+Videos in edit:
+  ✓ scene_001: /path/to/videos/scene_001_v0.mp4
+  ✓ scene_002: /path/to/videos/scene_002_v0.mp4  
+  ✓ scene_003: /path/to/videos/scene_003_v0.mp4
+
+Rendering...
+
+✓ Render complete!
+  Output: artifacts/runs/20260107_224324/renders/final_video.mp4
+  Duration: 45.2s
+  Size: 32.1 MB
+  Render time: 8.3s
+```
+
+---
+
+## mix - Video and Audio Mixing
+
+Mix a video file with TTS-generated audio or an existing audio file.
+
+### Synopsis
+
+```bash
+claude-studio render mix VIDEO_FILE [OPTIONS]
+```
+
+### Arguments
+
+#### `VIDEO_FILE`
+Path to input video file.
+
+**Supported formats:** MP4, AVI, MOV, MKV
+
+### Options
+
+#### Audio Source (choose one)
+
+##### `--text, -t TEXT`
+Text to convert to speech (TTS).
+
+Generates audio using available TTS providers (ElevenLabs or OpenAI).
+
+##### `--audio, -a PATH`
+Existing audio file to mix with video.
+
+**Supported formats:** MP3, WAV, AAC, M4A
+
+#### TTS Options
+
+##### `--voice, -v TEXT`
+Voice ID for TTS generation.
+
+**Default:** `Rachel`
+
+**ElevenLabs Voices:**
+- `Rachel` - Clear, professional female
+- `Adam` - Deep, authoritative male
+- `Lily` - Warm, engaging female
+
+**OpenAI Voices:**
+- `alloy`, `echo`, `fable`, `onyx`, `nova`, `shimmer`
+
+#### Mixing Options
+
+##### `--output, -o PATH`
+Output file path.
+
+**Default:** `<video_stem>_mixed.mp4`
+
+##### `--volume FLOAT`
+Audio volume adjustment in dB.
+
+**Default:** `0.0` (no change)
+**Range:** `-20.0` to `+20.0`
+
+##### `--fit CHOICE`
+How to handle video/audio length mismatch.
+
+**Choices:**
+- `shortest` - Trim output to shorter of video/audio (default)
+- `longest` - Freeze last video frame to match longer audio
+- `speed-match` - Adjust video playback speed to match audio
+
+### Examples
+
+#### TTS Generation and Mixing
+
+```bash
+# Generate TTS and mix with video
+claude-studio render mix video.mp4 --text "Hello world, this is a test."
+
+# Use specific voice
+claude-studio render mix video.mp4 -t "Welcome to our demo" -v Adam
+
+# Custom output file
+claude-studio render mix video.mp4 -t "Product introduction" -o final.mp4
+```
+
+#### Audio File Mixing
+
+```bash
+# Mix with existing audio file
+claude-studio render mix video.mp4 --audio narration.mp3
+
+# Adjust audio volume
+claude-studio render mix video.mp4 --audio narration.mp3 --volume -3.0
+
+# Handle length mismatch
+claude-studio render mix video.mp4 --audio long_narration.mp3 --fit longest
+```
+
+#### Advanced Mixing
+
+```bash
+# Speed-match video to audio duration
+claude-studio render mix video.mp4 --audio narration.mp3 --fit speed-match
+
+# Generate longer TTS with custom voice
+claude-studio render mix video.mp4 \
+  -t "This is a comprehensive explanation of our product features and benefits." \
+  -v "21m00Tcm4TlvDq8ikWAM" \
+  --fit longest \
+  -o product_demo.mp4
+```
+
+### Fit Modes Explained
+
+#### `shortest` (Default)
+- Output duration = min(video_duration, audio_duration)
+- Trims longer track to match shorter one
+- **Use case**: Quick demos, matched content
+
+#### `longest`  
+- Output duration = max(video_duration, audio_duration)
+- Freezes last video frame for longer audio
+- Loops video for longer audio (future feature)
+- **Use case**: Narration-driven content
+
+#### `speed-match`
+- Adjusts video playback speed to match audio duration
+- Maintains audio quality and timing
+- Video may appear slightly faster/slower
+- **Use case**: Precise audio-video synchronization
+
+### TTS Integration
+
+#### Provider Selection
+
+Mix command automatically selects TTS provider:
+
+1. **ElevenLabs** (preferred if API key available)
+   - Higher quality voice synthesis
+   - More natural intonation
+   - Voice ID support
+
+2. **OpenAI TTS** (fallback)
+   - HD quality (`tts-1-hd` model)
+   - Reliable and fast
+   - Standard voice options
+
+#### Voice Configuration
+
+```bash
+# Set TTS provider preference
+export TTS_PROVIDER=openai  # Force OpenAI TTS
+
+# Configure API keys
+claude-studio secrets set ELEVENLABS_API_KEY your_key
+claude-studio secrets set OPENAI_API_KEY your_key
+```
+
+### Audio Processing
+
+#### Volume Control
+
+```bash
+# Reduce audio volume by 6dB
+claude-studio render mix video.mp4 --audio loud_audio.mp3 --volume -6.0
+
+# Boost quiet audio by 3dB  
+claude-studio render mix video.mp4 --audio quiet_audio.mp3 --volume +3.0
+```
+
+#### Format Handling
+
+The mix command handles various audio formats:
+- **Input**: MP3, WAV, AAC, M4A, FLAC
+- **Output**: AAC in MP4 container (192kbps)
+- **Sample Rate**: Preserves original or 44.1kHz
+- **Channels**: Stereo or original channel configuration
+
+### Integration with Production Pipeline
+
+#### Testing Video Concepts
+
+```bash
+# Test video with different narration
+claude-studio render mix concept_video.mp4 \
+  -t "Version 1: Professional tone" \
+  -v Rachel \
+  -o test_v1.mp4
+
+claude-studio render mix concept_video.mp4 \
+  -t "Version 2: Conversational tone" \
+  -v Adam \
+  -o test_v2.mp4
+```
+
+#### Prototyping Audio-Video Combinations
+
+```bash
+# Test different fit modes
+claude-studio render mix short_video.mp4 --audio long_narration.mp3 --fit longest -o extended.mp4
+claude-studio render mix long_video.mp4 --audio short_narration.mp3 --fit shortest -o trimmed.mp4
+```
+
+#### Quick Video Enhancement
+
+```bash
+# Add narration to silent video
+claude-studio render mix silent_demo.mp4 \
+  -t "This demonstration shows our key features in action." \
+  --fit longest \
+  -o narrated_demo.mp4
+```
+
+## FFmpeg Requirements
+
+Both render commands require FFmpeg installation:
+
+### Installation
+
+```bash
+# macOS
+brew install ffmpeg
+
+# Ubuntu/Debian
+sudo apt update && sudo apt install ffmpeg
+
+# Windows
+# Download from https://ffmpeg.org/download.html
+```
+
+### Verification
+
+```bash
+# Check FFmpeg installation
+ffmpeg -version
+
+# Check available codecs
+ffmpeg -codecs | grep -E "(h264|aac)"
+```
+
+### Required Components
+
+- **Video Codec**: libx264 for H.264 encoding
+- **Audio Codec**: AAC for audio encoding
+- **Formats**: MP4 container support
+- **Filters**: Scale, concat, and overlay filters
+
+## Performance and Quality
+
+### Render Settings
+
+#### Video Quality
+- **Codec**: H.264 (libx264)
+- **Preset**: `fast` (balanced speed/quality)
+- **CRF**: 23 (high quality, reasonable size)
+- **Pixel Format**: yuv420p (maximum compatibility)
+
+#### Audio Quality
+- **Codec**: AAC-LC
+- **Bitrate**: 192kbps (high quality)
+- **Sample Rate**: 44.1kHz or original
+- **Channels**: Stereo
+
+#### Optimization
+- **Hardware Acceleration**: Uses system capabilities when available
+- **Multi-threading**: Parallel processing for faster renders
+- **Memory Management**: Efficient for large video files
+
+### File Size Optimization
+
+```bash
+# High quality (larger file)
+claude-studio render edl run_id -o hq_video.mp4
+
+# For web streaming, use external tools:
+ffmpeg -i hq_video.mp4 -crf 28 -preset slow web_optimized.mp4
+```
+
+## Troubleshooting
+
+### Common Issues
+
+#### FFmpeg Not Found
+```bash
+Error: FFmpeg not installed
+```
+**Solution:** Install FFmpeg using system package manager
+
+#### Video Files Missing
+```bash
+Error: Video file not found: /path/to/scene_001.mp4
+```
+**Solution:** Verify production run completed successfully
+
+#### Audio Generation Failed
+```bash
+Error: TTS generation failed - no audio data returned
+```
+**Solution:** Check API keys and TTS provider configuration
+
+#### Format Compatibility
+```bash
+Error: Unsupported video format: .webm
+```
+**Solution:** Convert input video to MP4 format first
+
+### Debug Information
+
+#### EDL Rendering Debug
+```bash
+# Check EDL structure
+cat artifacts/runs/<run_id>/edl/edit_candidates.json | jq .
+
+# Verify video files exist
+ls -la artifacts/runs/<run_id>/videos/
+
+# Test individual video file
+ffplay artifacts/runs/<run_id>/videos/scene_001_v0.mp4
+```
+
+#### Mix Command Debug
+```bash
+# Check input video properties
+ffprobe -v quiet -print_format json -show_format video.mp4
+
+# Test TTS generation separately
+claude-studio test-provider elevenlabs -t "test" --live
+
+# Verify audio file format
+ffprobe -v quiet -print_format json -show_format audio.mp3
+```
+
+## Advanced Usage
+
+### Batch Processing
+
+```bash
+# Render multiple EDL candidates
+for candidate in standard_cut creative_cut minimal_cut; do
+  claude-studio render edl 20260107_224324 -c "$candidate" -o "${candidate}.mp4"
+done
+
+# Mix multiple videos with same audio
+for video in *.mp4; do
+  claude-studio render mix "$video" --audio narration.mp3 -o "mixed_${video}"
+done
+```
+
+### Custom Workflows
+
+```bash
+# Production to final video pipeline
+#!/bin/bash
+RUN_ID="$1"
+OUTPUT_DIR="final_videos"
+
+# Create output directory
+mkdir -p "$OUTPUT_DIR"
+
+# Render all candidates
+claude-studio render edl "$RUN_ID" --list-candidates | \
+  grep -E "^\│ [a-z_]+" | \
+  awk '{print $2}' | \
+  while read candidate; do
+    claude-studio render edl "$RUN_ID" -c "$candidate" -o "${OUTPUT_DIR}/${candidate}.mp4"
+  done
+
+echo "All candidates rendered to $OUTPUT_DIR/"
+```
+
+### Quality Comparison
+
+```bash
+# Render with different quality settings using raw ffmpeg
+claude-studio render edl run_id -o source.mp4
+
+# High quality version
+ffmpeg -i source.mp4 -crf 18 -preset slow high_quality.mp4
+
+# Web optimized version  
+ffmpeg -i source.mp4 -crf 28 -preset medium web_quality.mp4
+
+# Mobile optimized version
+ffmpeg -i source.mp4 -crf 30 -s 1280x720 mobile_quality.mp4
+```
+
+## Integration Examples
+
+### Complete Production Workflow
+
+```bash
+#!/bin/bash
+# Complete video production and rendering pipeline
+
+# 1. Generate video
+claude-studio produce -c "Product demonstration" -b 25 -d 45 --live -p luma
+
+# 2. Resume if needed
+claude-studio resume latest --live
+
+# 3. Get run ID
+RUN_ID=$(ls -t artifacts/runs/ | head -1)
+
+# 4. Render final video
+claude-studio render edl "$RUN_ID" -o final_product_demo.mp4
+
+# 5. Create web-optimized version
+ffmpeg -i final_product_demo.mp4 -crf 28 -s 1920x1080 web_demo.mp4
+
+# 6. Upload to platforms
+claude-studio upload youtube web_demo.mp4 -t "Product Demo" --privacy unlisted
+
+echo "Production complete: web_demo.mp4"
+```
+
+### Audio-Video Testing Workflow  
+
+```bash
+#!/bin/bash  
+# Test different audio options for video
+
+VIDEO="concept_video.mp4"
+BASE_NAME=$(basename "$VIDEO" .mp4)
+
+# Generate TTS variations
+claude-studio render mix "$VIDEO" -t "Professional presentation" -v Rachel -o "${BASE_NAME}_rachel.mp4"
+claude-studio render mix "$VIDEO" -t "Professional presentation" -v Adam -o "${BASE_NAME}_adam.mp4"
+
+# Test with existing audio
+claude-studio render mix "$VIDEO" --audio background_music.mp3 --fit longest -o "${BASE_NAME}_music.mp4"
+
+echo "Audio variations created:"
+ls -la "${BASE_NAME}"_*.mp4
+```
+
+## Version History
+
+- **0.6.0**: Enhanced audio mixing with multiple fit modes and TTS integration
+- **0.5.x**: EDL rendering with transitions and text overlays
+- **0.4.x**: Basic video concatenation and rendering

--- a/docs/cli/resume.md
+++ b/docs/cli/resume.md
@@ -1,0 +1,546 @@
+# resume - Resume Interrupted Productions
+
+The `resume` command continues a production from where it stopped, picking up from existing assets and completing the remaining pipeline stages. This is essential for handling interrupted productions due to API limits, network issues, or system interruptions.
+
+## Synopsis
+
+```bash
+claude-studio resume RUN_ID [OPTIONS]
+```
+
+## Description
+
+The resume command intelligently continues production by:
+
+- Loading existing scenes, videos, and run metadata
+- Detecting which pipeline stages have been completed
+- Resuming from the appropriate stage (QA verification, critic analysis, or EDL creation)
+- Preserving all existing work and budget tracking
+- Handling mixed video + audio assembly if audio files exist
+
+## Required Arguments
+
+### `RUN_ID`
+Run directory name or path to resume.
+
+**Special Values:**
+- `latest` - Resume the most recent production run
+- `<timestamp>` - Resume specific run (e.g., `20260131_162250`)
+- `<path>` - Resume from custom directory path
+
+**Examples:**
+- `claude-studio resume latest`
+- `claude-studio resume 20260131_162250`
+- `claude-studio resume ./my_custom_run`
+
+## Options
+
+### Execution Control
+
+#### `--live`
+Use live QA with Claude Vision.
+
+When enabled, performs real video quality analysis using Claude's vision capabilities. Without this flag, uses mock QA scores.
+
+#### `--skip-qa`
+Skip QA verification stage.
+
+Use when QA verification has already been completed or when you want to proceed without quality analysis.
+
+#### `--skip-critic`
+Skip critic analysis stage.
+
+Bypasses the production quality scoring and approval process.
+
+#### `--skip-editor`
+Skip EDL creation stage.
+
+Prevents generation of Edit Decision Lists, useful when only wanting QA/critic analysis.
+
+## Examples
+
+### Basic Usage
+
+```bash
+# Resume latest production run
+claude-studio resume latest
+
+# Resume specific run with live QA
+claude-studio resume 20260131_162250 --live
+
+# Resume with all stages
+claude-studio resume my_run_id --live
+```
+
+### Selective Stage Execution
+
+```bash
+# Skip QA if already completed
+claude-studio resume latest --skip-qa --live
+
+# Only run QA and critic, skip EDL
+claude-studio resume latest --live --skip-editor
+
+# Fast resume with mock QA
+claude-studio resume latest --skip-critic --skip-editor
+```
+
+### Development Workflows
+
+```bash
+# Quick QA check without full pipeline
+claude-studio resume latest --live --skip-critic --skip-editor
+
+# Generate EDL from existing QA results
+claude-studio resume latest --skip-qa --skip-critic
+
+# Complete production with real analysis
+claude-studio resume latest --live
+```
+
+## Resume Detection Logic
+
+### Run Directory Requirements
+
+The resume command requires these artifacts in the run directory:
+
+**Required:**
+- `memory.json` - Run metadata and stage tracking
+- `scenes/` - Scene specification files
+- `videos/` - Generated video files
+
+**Optional:**
+- `qa/` - QA analysis results (if QA completed)
+- `critic_results.json` - Critic evaluation (if critic completed)
+- `audio/` - Audio files for mixed output
+
+### Stage Detection
+
+The command automatically detects completion status:
+
+1. **Memory Analysis**: Checks `memory.json` for completed stages
+2. **Asset Discovery**: Scans for QA files, critic results, EDLs
+3. **Smart Resume**: Starts from first incomplete stage
+
+**Example Detection:**
+```bash
+# Run status detection
+Concept: Product demo for mobile app
+Budget: $2.50 / $15.00 spent  
+Current stage: video_generation
+
+# Detected completion:
+✓ Scenes loaded (5 scenes)
+✓ Videos loaded (5 videos)  
+○ QA verification needed
+○ Critic analysis needed
+○ EDL creation needed
+```
+
+## Resume Pipeline Stages
+
+### Stage 1: Asset Loading
+
+1. **Memory Loading**
+   - Reads `memory.json` for run metadata
+   - Extracts concept, budget, and progress information
+   - Calculates actual budget spent from timeline
+
+2. **Scene Loading**
+   - Reconstructs Scene objects from `scenes/*.json`
+   - Preserves all scene metadata and specifications
+   - Validates scene integrity and completeness
+
+3. **Video Loading**
+   - Discovers all `videos/scene_*_v*.mp4` files
+   - Creates GeneratedVideo objects with correct metadata
+   - Measures actual video durations using ffprobe
+   - Maps videos to scenes and variations
+
+### Stage 2: QA Verification (if not skipped)
+
+1. **QA Results Discovery**
+   - Checks for existing `qa/scene_*_v*_qa.json` files
+   - Loads previous QA results if available
+   - Only runs QA on videos without existing analysis
+
+2. **Quality Analysis**
+   - Uses QAVerifierAgent with Claude Vision (if `--live`)
+   - Analyzes video quality across multiple dimensions:
+     - Visual accuracy against scene description
+     - Style consistency across the production
+     - Technical quality (resolution, artifacts)
+     - Narrative fit with original concept
+
+3. **Checkpoint Saving**
+   - Saves QA results immediately after each video
+   - Enables resumption even if QA is interrupted
+   - Updates video quality scores in memory
+
+**QA Output Example:**
+```bash
+Analyzing scene_001: Logo reveal animation
+  v0: 85.5/100 ✓ (passed)
+  
+Analyzing scene_002: Product demonstration  
+  v0: 72.1/100 ✓ (passed)
+  
+QA complete: 4/5 passed (80%)
+```
+
+### Stage 3: Critic Analysis (if not skipped)
+
+1. **Scene Results Compilation**
+   - Builds SceneResult objects from videos and QA data
+   - Selects best video variation per scene (highest QA score)
+   - Combines generation costs and quality metrics
+
+2. **Production Evaluation**
+   - Uses CriticAgent for holistic production assessment
+   - Evaluates budget efficiency and concept realization
+   - Provides approval recommendation and feedback
+
+3. **Results Storage**
+   - Saves critic results to `critic_results.json`
+   - Prevents re-analysis on subsequent resumes
+   - Includes quality scores and approval reasoning
+
+**Critic Output Example:**
+```bash
+Overall score: 78.5/100
+Approved: true
+Reasoning: Strong visual coherence and effective concept realization. 
+Minor audio-visual sync improvements possible.
+```
+
+### Stage 4: Edit Decision List Creation (if not skipped)
+
+1. **Asset Compilation**
+   - Combines video assets, QA results, and audio files
+   - Maps audio files to scenes if available
+   - Prepares complete asset inventory for editing
+
+2. **EDL Generation**
+   - Uses EditorAgent to create multiple edit candidates
+   - Recommends optimal edit based on quality and flow
+   - Specifies transitions, timing, and effects
+
+3. **Audio-Video Mixing** (if audio available)
+   - Detects audio files in `audio/` directory
+   - Mixes video with audio using appropriate fit mode
+   - Creates final concatenated output video
+   - Saves mixed scenes and final result
+
+**EDL Output Example:**
+```bash
+Candidate: Standard Cut (recommended)
+Edit decisions: 5 scenes
+Total duration: 32.5s
+Quality: 81.2/100
+
+✓ Mixed scene_001 (video + audio)
+✓ Mixed scene_002 (video + audio)
+...
+✓ Final output: final_output.mp4
+```
+
+## Audio-Video Integration
+
+### Audio Detection
+
+Resume automatically detects audio assets:
+
+```bash
+# Audio files detected
+Found audio files:
+  scene_001.mp3 (12.5s)
+  scene_002.mp3 (8.2s)
+  scene_003.mp3 (11.8s)
+```
+
+### Mixing Process
+
+When audio is available, resume performs audio-video mixing:
+
+1. **Individual Scene Mixing**
+   - Combines each video with corresponding audio
+   - Uses appropriate fit mode (truncate for video-led)
+   - Saves mixed results to `mixed/` directory
+
+2. **Final Concatenation**
+   - Concatenates all mixed scenes
+   - Creates seamless final video with audio
+   - Saves as `final_output.mp4`
+
+### Fit Modes
+
+- **Video-led** (default): Audio is truncated to match video duration
+- **Audio-led**: Video is stretched/held to match audio duration
+
+## Memory and Budget Tracking
+
+### Budget Calculation
+
+Resume accurately tracks spent budget:
+
+```json
+{
+  "budget_total": 15.00,
+  "timeline": [
+    {
+      "stage": "video_generation", 
+      "details": {"cost": 2.50}
+    },
+    {
+      "stage": "qa_verification",
+      "details": {"cost": 0.00}
+    }
+  ]
+}
+```
+
+Budget spent is calculated from timeline entries, not stale `budget_spent` field.
+
+### Progress Tracking
+
+Resume maintains detailed progress information:
+
+- **Completed Stages**: Which pipeline stages finished successfully
+- **Asset Inventory**: Count and status of generated assets
+- **Quality Metrics**: QA scores and critic evaluations
+- **Timing Information**: Duration of each production stage
+
+## Error Recovery
+
+### Partial Completion Handling
+
+Resume gracefully handles various interruption scenarios:
+
+**Video Generation Interrupted:**
+```bash
+# Some videos missing
+Warning: scene_003 has no videos - will be skipped in QA
+```
+
+**QA Partially Complete:**
+```bash
+# QA results exist for some videos
+Found 3 existing QA results
+Loading existing QA data...
+✓ Loaded QA results for 3 scenes
+```
+
+**Audio-Video Mismatch:**
+```bash
+# Audio duration doesn't match video
+Warning: Audio duration mismatch for scene_002: expected 10s, got 8s
+Using video duration for mixing
+```
+
+### Corrupted Data Recovery
+
+Resume validates data integrity:
+
+```bash
+# Invalid scene data
+Error loading scene_003.json: Invalid JSON format
+Skipping corrupted scene file
+
+# Missing video files
+Warning: scene_002_v0.mp4 not found
+Removing from candidate list
+```
+
+## Integration with Other Commands
+
+### Production Pipeline Integration
+
+Resume fits into the complete production workflow:
+
+```bash
+# 1. Start production
+claude-studio produce -c "Product demo" -b 20 --live -p luma
+
+# 2. Production interrupted (API limit, network, etc.)
+# ... interruption occurs ...
+
+# 3. Resume from where it stopped  
+claude-studio resume latest --live
+
+# 4. Use results with other commands
+claude-studio render edl <run_id>
+claude-studio upload youtube <run_id>/final_output.mp4
+```
+
+### Asset Management Integration
+
+Resume works with asset management commands:
+
+```bash
+# Resume to complete QA
+claude-studio resume latest --live --skip-critic --skip-editor
+
+# Review assets based on QA results
+claude-studio assets list <run_id> --status draft
+
+# Approve/reject based on QA scores
+claude-studio assets approve <run_id> --image 1,3,5  # High QA scores
+claude-studio assets reject <run_id> --image 2,4 --reason "low QA scores"
+```
+
+## Debugging and Troubleshooting
+
+### Common Issues
+
+#### Missing Run Directory
+```bash
+Error: Run directory not found: 20260131_999999
+```
+**Solution:** Check run ID spelling or use `latest`
+
+#### Corrupted Memory File
+```bash
+Error: memory.json not found in run directory
+```
+**Solution:** Run directory may not be from `produce` command
+
+#### FFmpeg Issues
+```bash
+Error getting video duration: ffprobe not found
+```
+**Solution:** Install FFmpeg for video duration detection
+
+#### API Configuration
+```bash
+Warning: Claude API key not set, using mock QA mode
+```
+**Solution:** Set `ANTHROPIC_API_KEY` for live QA analysis
+
+### Debug Information
+
+Resume provides detailed progress information:
+
+```bash
+# Run information
+Concept: Product demo for mobile app
+Budget: $2.50 / $15.00 spent
+Current stage: video_generation
+
+# Asset inventory
+✓ Loaded 5 scenes
+✓ Loaded 8 videos  
+✓ Found 3 audio files
+
+# Stage status
+✓ Scenes generated
+✓ Videos generated  
+○ QA verification needed
+○ Critic analysis needed
+○ EDL creation needed
+```
+
+### Manual Inspection
+
+For troubleshooting, manually inspect run directories:
+
+```bash
+# Check run structure
+ls -la artifacts/runs/<run_id>/
+
+# Verify video files exist
+ls -la artifacts/runs/<run_id>/videos/
+
+# Check existing QA results  
+ls -la artifacts/runs/<run_id>/qa/
+
+# Review memory file
+cat artifacts/runs/<run_id>/memory.json | jq .
+```
+
+## Performance Considerations
+
+### Incremental Processing
+
+Resume only processes what's needed:
+
+- **QA**: Only analyzes videos without existing results
+- **Critic**: Reuses existing analysis if available
+- **EDL**: Creates new EDLs based on current assets
+
+### Network Optimization
+
+For live QA analysis:
+- Processes videos sequentially to avoid rate limits
+- Saves results immediately as checkpoints
+- Enables resumption if network interruption occurs
+
+### Storage Efficiency
+
+Resume preserves existing work:
+- Doesn't regenerate existing assets
+- Reuses QA analysis and critic evaluations  
+- Only creates new files for missing stages
+
+## Advanced Usage
+
+### Selective Resume Strategies
+
+```bash
+# QA-only resume (for quality assessment)
+claude-studio resume latest --live --skip-critic --skip-editor
+
+# Full pipeline resume (complete all stages)
+claude-studio resume latest --live
+
+# Fast completion (skip expensive QA)
+claude-studio resume latest --skip-qa
+```
+
+### Batch Resume Processing
+
+```bash
+# Resume multiple interrupted runs
+for run_id in $(ls artifacts/runs/); do
+  if [ ! -f "artifacts/runs/$run_id/final_output.mp4" ]; then
+    echo "Resuming $run_id..."
+    claude-studio resume "$run_id" --live
+  fi
+done
+```
+
+### Development Iteration
+
+```bash
+# Fast iteration for EDL testing
+claude-studio resume latest --skip-qa --skip-critic
+
+# QA testing without full pipeline
+claude-studio resume latest --live --skip-critic --skip-editor
+```
+
+## Output Structure After Resume
+
+Successful resume creates complete output structure:
+
+```
+artifacts/runs/<run_id>/
+├── scenes/                     # Original scene specs
+├── videos/                     # Generated video files
+├── qa/                        # QA analysis results  
+│   ├── scene_001_v0_qa.json
+│   └── ...
+├── critic_results.json        # Critic evaluation
+├── edl/                       # Edit Decision Lists
+│   └── final.json
+├── mixed/                     # Audio-video mixed scenes
+│   ├── scene_001_mixed.mp4
+│   └── ...
+├── final_output.mp4           # Complete final video
+└── memory.json                # Updated run metadata
+```
+
+## Version History
+
+- **0.6.0**: Audio-video mixing integration and improved error recovery
+- **0.5.x**: Multi-stage resume with QA checkpointing
+- **0.4.x**: Basic production resume functionality

--- a/docs/cli/training.md
+++ b/docs/cli/training.md
@@ -29,7 +29,7 @@ cs training run --with-audio
 | `--max-trials` | int | 5 | Maximum number of training trials |
 | `--with-audio` | flag | | Generate TTS audio (disabled by default, uses reference audio) |
 
-**Training pairs** should contain matched audio + transcript files in the pairs directory.
+**Training pairs** are discovered by matching same-basename `.pdf` and `.mp3` files in the pairs directory (e.g., `episode01.pdf` + `episode01.mp3`).
 
 ---
 

--- a/docs/cli/training.md
+++ b/docs/cli/training.md
@@ -1,0 +1,46 @@
+# Training (`cs training`)
+
+Podcast calibration pipeline. Analyzes reference audio/transcript pairs to learn style, pacing, and structure profiles for higher-quality script generation.
+
+## Commands
+
+| Command | Description |
+|---------|-------------|
+| `training run` | Run the training pipeline on reference pairs |
+| `training list-pairs` | List available training data pairs |
+
+---
+
+## `training run`
+
+Run the full training pipeline on reference podcast pairs.
+
+```bash
+cs training run
+cs training run --pairs-dir ./my_pairs --output-dir ./results --max-trials 10
+cs training run --with-audio
+```
+
+**Options:**
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `--pairs-dir` | path | `artifacts/training_data` | Directory containing training pairs |
+| `--output-dir` | path | `artifacts/training_output` | Output directory for results |
+| `--max-trials` | int | 5 | Maximum number of training trials |
+| `--with-audio` | flag | | Generate TTS audio (disabled by default, uses reference audio) |
+
+**Training pairs** should contain matched audio + transcript files in the pairs directory.
+
+---
+
+## `training list-pairs`
+
+List available training data pairs.
+
+```bash
+cs training list-pairs
+cs training list-pairs ./custom_pairs_dir
+```
+
+**Arguments:**
+- `PAIRS_DIR` — Directory to scan (default: `artifacts/training_data`)

--- a/docs/cli/upload.md
+++ b/docs/cli/upload.md
@@ -1,0 +1,597 @@
+# upload - Video Upload to Platforms
+
+The `upload` command provides video upload capabilities to various platforms, with comprehensive YouTube integration for OAuth2-based uploads and metadata management.
+
+## Synopsis
+
+```bash
+claude-studio upload COMMAND [OPTIONS]
+```
+
+## Description
+
+The upload command handles:
+
+- OAuth2 authentication with platform APIs
+- Video uploads with metadata (title, description, tags)
+- Privacy controls and publishing options
+- Upload record tracking and metadata preservation
+- Post-upload metadata updates
+
+## Commands Overview
+
+| Command | Purpose |
+|---------|---------|
+| `youtube` | Upload video to YouTube |
+| `youtube-update` | Update YouTube video metadata |
+| `youtube-auth` | Set up YouTube OAuth2 authentication |
+
+---
+
+## Setup and Authentication
+
+### YouTube OAuth2 Configuration
+
+YouTube uploads require OAuth2 credentials from Google Cloud Console.
+
+#### Step 1: Google Cloud Console Setup
+
+1. Go to [Google Cloud Console](https://console.cloud.google.com/)
+2. Create a new project or select existing project
+3. Navigate to **APIs & Services** → **Credentials**
+4. Create **OAuth 2.0 Client ID** for **Desktop Application**
+5. Download credentials or note Client ID and Secret
+
+#### Step 2: Configure Credentials
+
+**Option 1 - Keychain (Recommended):**
+```bash
+claude-studio secrets set YOUTUBE_CLIENT_ID your_client_id
+claude-studio secrets set YOUTUBE_CLIENT_SECRET your_client_secret
+```
+
+**Option 2 - JSON File:**
+```bash
+# Download client_secrets.json from Google Cloud Console
+claude-studio secrets set YOUTUBE_CLIENT_SECRETS_PATH /path/to/client_secrets.json
+```
+
+#### Step 3: Authenticate
+
+```bash
+# Authorize account access (opens browser)
+claude-studio upload youtube-auth
+```
+
+This stores an authentication token for future uploads.
+
+---
+
+## youtube - Upload to YouTube
+
+Upload a video file to YouTube with metadata and privacy controls.
+
+### Synopsis
+
+```bash
+claude-studio upload youtube VIDEO_PATH [OPTIONS]
+```
+
+### Arguments
+
+#### `VIDEO_PATH`
+Path to video file to upload.
+
+**Supported formats:** MP4, AVI, MOV, MKV, WebM
+**Recommended:** MP4 with H.264 video and AAC audio
+
+### Options
+
+#### Required Options
+
+##### `--title, -t TEXT`
+Video title (required).
+
+**Length limit:** 100 characters
+**Tips:** Clear, descriptive, keyword-rich titles perform better
+
+##### `--description, -d TEXT`
+Video description (default: empty).
+
+**Length limit:** 5,000 characters
+**Supports:** Line breaks, URLs, timestamps
+
+#### Content Classification
+
+##### `--tags TEXT`
+Comma-separated video tags.
+
+**Format:** `"tag1,tag2,tag3"`
+**Limit:** 500 characters total
+**Tips:** Use relevant, specific tags
+
+##### `--category TEXT`
+YouTube category ID (default: "27" - Education).
+
+**Common Categories:**
+- `1` - Film & Animation
+- `2` - Autos & Vehicles
+- `10` - Music
+- `15` - Pets & Animals
+- `17` - Sports
+- `19` - Travel & Events
+- `20` - Gaming
+- `22` - People & Blogs
+- `23` - Comedy
+- `24` - Entertainment
+- `25` - News & Politics
+- `26` - Howto & Style
+- `27` - Education (default)
+- `28` - Science & Technology
+
+#### Privacy and Publishing
+
+##### `--privacy CHOICE`
+Video privacy status (default: "unlisted").
+
+**Choices:**
+- `public` - Anyone can search and view
+- `unlisted` - Only people with link can view
+- `private` - Only you can view
+
+##### `--notify / --no-notify`
+Notify subscribers about upload (default: False).
+
+Only applies to public videos. Subscribers receive notifications when enabled.
+
+### Examples
+
+#### Basic Upload
+
+```bash
+# Simple upload with required title
+claude-studio upload youtube my_video.mp4 -t "My Amazing Video"
+
+# Upload with description and tags
+claude-studio upload youtube demo.mp4 \
+  -t "Product Demo - New Features" \
+  -d "Comprehensive overview of our latest product features and improvements." \
+  --tags "product,demo,tutorial,features"
+```
+
+#### Advanced Upload Configuration
+
+```bash
+# Upload as public video with notifications
+claude-studio upload youtube tutorial.mp4 \
+  -t "How to Use Claude Studio Producer" \
+  -d "Step-by-step tutorial for creating AI-generated videos using Claude Studio Producer." \
+  --tags "AI,video,tutorial,claude,automation" \
+  --category 27 \
+  --privacy public \
+  --notify
+
+# Upload to specific category
+claude-studio upload youtube gaming_video.mp4 \
+  -t "Epic Gaming Moments Compilation" \
+  --category 20 \
+  --privacy unlisted
+```
+
+#### Production Pipeline Integration
+
+```bash
+# Upload final production video
+FINAL_VIDEO="artifacts/runs/20260207_143022/final_output.mp4"
+claude-studio upload youtube "$FINAL_VIDEO" \
+  -t "AI-Generated Explainer Video" \
+  -d "Created using Claude Studio Producer's multi-agent video production pipeline." \
+  --tags "AI,automation,video production,explainer" \
+  --privacy unlisted
+```
+
+### Upload Output
+
+```bash
+claude-studio upload youtube demo.mp4 -t "Product Demo"
+
+┌─ YouTube Upload ────────────────────────────────────┐
+│ ✓ Upload complete!                                  │
+│                                                     │
+│ Video ID: dQw4w9WgXcQ                              │
+│ URL: https://youtu.be/dQw4w9WgXcQ                   │
+│ Privacy: unlisted                                   │
+└─────────────────────────────────────────────────────┘
+```
+
+### Upload Metadata Tracking
+
+Upload records are automatically saved:
+
+#### Upload Record (`upload_record.json`)
+```json
+[
+  {
+    "platform": "youtube",
+    "video_id": "dQw4w9WgXcQ", 
+    "url": "https://youtu.be/dQw4w9WgXcQ",
+    "title": "Product Demo",
+    "description": "Demo of key features",
+    "tags": ["product", "demo", "tutorial"],
+    "privacy": "unlisted",
+    "uploaded_at": "2026-02-07T14:30:22Z",
+    "source_file": "demo.mp4"
+  }
+]
+```
+
+#### Assembly Manifest Integration
+If video is from production run, upload metadata is added to assembly manifest.
+
+---
+
+## youtube-update - Update Video Metadata
+
+Update YouTube video metadata after upload.
+
+### Synopsis
+
+```bash
+claude-studio upload youtube-update VIDEO_ID [OPTIONS]
+```
+
+### Arguments
+
+#### `VIDEO_ID`
+YouTube video ID to update.
+
+**Format:** 11-character alphanumeric string (e.g., `dQw4w9WgXcQ`)
+
+### Options
+
+#### `--title TEXT`
+New video title.
+
+#### `--description TEXT`
+New video description.
+
+#### `--tags TEXT`
+New comma-separated tags.
+
+#### `--privacy CHOICE`
+New privacy status.
+
+**Choices:** `public`, `unlisted`, `private`
+
+#### `--category TEXT`
+New category ID.
+
+### Examples
+
+```bash
+# Update title and description
+claude-studio upload youtube-update dQw4w9WgXcQ \
+  --title "Updated Product Demo - Version 2.0" \
+  --description "Updated demo showcasing the latest features and improvements."
+
+# Change privacy to public
+claude-studio upload youtube-update dQw4w9WgXcQ --privacy public
+
+# Update tags and category
+claude-studio upload youtube-update dQw4w9WgXcQ \
+  --tags "product,demo,v2,new features,tutorial" \
+  --category 28
+
+# Update multiple fields
+claude-studio upload youtube-update dQw4w9WgXcQ \
+  --title "Complete Product Overview" \
+  --description "Comprehensive guide to all product features." \
+  --tags "complete,guide,product,overview" \
+  --privacy public
+```
+
+---
+
+## youtube-auth - Authentication Setup
+
+Set up YouTube OAuth2 authentication for uploads.
+
+### Synopsis
+
+```bash
+claude-studio upload youtube-auth
+```
+
+### Description
+
+The auth command:
+
+1. Opens browser window for Google account authorization
+2. Requests necessary YouTube API scopes
+3. Stores authentication token for future uploads
+4. Only needs to be run once per account
+
+### Examples
+
+```bash
+# Initial authentication setup
+claude-studio upload youtube-auth
+
+# Re-authenticate if token expired
+claude-studio upload youtube-auth
+```
+
+### Authentication Flow
+
+```bash
+claude-studio upload youtube-auth
+
+[yellow]Opening browser for YouTube authorization...[/yellow]
+[green]✓ YouTube authentication successful! Token stored for future uploads.[/green]
+```
+
+### Scopes Requested
+
+The authentication requests these YouTube API scopes:
+- `https://www.googleapis.com/auth/youtube.upload`
+- `https://www.googleapis.com/auth/youtube`
+
+These allow:
+- Video uploads
+- Metadata management (title, description, tags)
+- Privacy controls
+- Basic channel information access
+
+---
+
+## Error Handling and Troubleshooting
+
+### Common Issues
+
+#### Missing Credentials
+```bash
+┌─ YouTube Setup Required ────────────────────────────┐
+│ YouTube OAuth2 credentials not configured.          │
+│                                                     │
+│ Option 1 — Keychain (recommended):                  │
+│   claude-studio secrets set YOUTUBE_CLIENT_ID <id>  │
+│   claude-studio secrets set YOUTUBE_CLIENT_SECRET <secret> │
+│                                                     │
+│ Option 2 — JSON file:                               │
+│   claude-studio secrets set YOUTUBE_CLIENT_SECRETS_PATH /path/to/file │
+└─────────────────────────────────────────────────────┘
+```
+
+**Solution:** Configure credentials as shown above
+
+#### Authentication Issues
+```bash
+✗ Authentication failed.
+```
+
+**Common causes:**
+- Browser blocked popup windows
+- Incorrect credentials
+- API not enabled in Google Cloud Console
+
+**Solutions:**
+- Allow popups for authentication
+- Verify credentials in Google Cloud Console
+- Enable YouTube Data API v3 in Google Cloud Console
+
+#### Upload Failures
+```bash
+✗ Upload failed: The request cannot be completed because you have exceeded your quota.
+```
+
+**Common causes:**
+- YouTube API quota exceeded
+- Video file too large
+- Unsupported video format
+- Network connectivity issues
+
+**Solutions:**
+- Wait for quota reset (daily limits)
+- Compress video file size
+- Convert to MP4 format
+- Check internet connection
+
+#### Permission Errors
+```bash
+✗ Update failed: Insufficient permissions
+```
+
+**Cause:** Token doesn't have required scopes
+
+**Solution:**
+```bash
+# Re-authenticate to refresh token and scopes
+claude-studio upload youtube-auth
+```
+
+### Debug Information
+
+#### Check API Quotas
+YouTube API has daily quotas:
+- **Upload quota:** 6 uploads per day (default)
+- **API calls:** 10,000 units per day
+- **Video uploads:** Count as 1,600 units each
+
+#### Verify Credentials
+```bash
+# Check if credentials are configured
+claude-studio secrets list | grep YOUTUBE
+
+# Test authentication without upload
+claude-studio upload youtube-auth
+```
+
+#### Video Format Validation
+```bash
+# Check video properties
+ffprobe -v quiet -print_format json -show_format video.mp4
+
+# Convert to YouTube-optimized format if needed
+ffmpeg -i input.mov -c:v libx264 -c:a aac -preset slow -crf 22 output.mp4
+```
+
+## Production Workflow Integration
+
+### Automated Upload Pipeline
+
+```bash
+#!/bin/bash
+# Automated production and upload pipeline
+
+SCRIPT_FILE="$1"
+VIDEO_TITLE="$2"
+
+# Generate video
+echo "Starting video production..."
+claude-studio produce-video --script "$SCRIPT_FILE" --live --kb-project research
+
+# Get output directory
+OUTPUT_DIR=$(ls -t artifacts/video_production/ | head -1)
+FINAL_VIDEO="artifacts/video_production/$OUTPUT_DIR/assembly/rough_cut.mp4"
+
+# Upload to YouTube
+echo "Uploading to YouTube..."
+claude-studio upload youtube "$FINAL_VIDEO" \
+  -t "$VIDEO_TITLE" \
+  -d "Generated using Claude Studio Producer AI video pipeline." \
+  --tags "AI,automation,video production" \
+  --privacy unlisted
+
+echo "Production and upload complete!"
+```
+
+### Batch Upload Processing
+
+```bash
+#!/bin/bash
+# Upload multiple videos with metadata
+
+VIDEOS_DIR="final_videos"
+METADATA_FILE="video_metadata.csv"
+
+# CSV format: filename,title,description,tags,privacy
+while IFS=, read -r filename title description tags privacy; do
+  if [ -f "$VIDEOS_DIR/$filename" ]; then
+    echo "Uploading $filename..."
+    claude-studio upload youtube "$VIDEOS_DIR/$filename" \
+      -t "$title" \
+      -d "$description" \
+      --tags "$tags" \
+      --privacy "$privacy"
+  fi
+done < "$METADATA_FILE"
+```
+
+### Content Series Management
+
+```bash
+# Upload video series with consistent formatting
+SERIES_NAME="AI Tutorial Series"
+EPISODE_NUM=1
+
+for video in series_*.mp4; do
+  EPISODE_TITLE="$SERIES_NAME - Episode $EPISODE_NUM: $(basename "$video" .mp4)"
+  
+  claude-studio upload youtube "$video" \
+    -t "$EPISODE_TITLE" \
+    -d "Part $EPISODE_NUM of the comprehensive AI tutorial series." \
+    --tags "AI,tutorial,series,episode $EPISODE_NUM" \
+    --category 27 \
+    --privacy unlisted
+  
+  ((EPISODE_NUM++))
+done
+```
+
+## Best Practices
+
+### Video Optimization
+
+```bash
+# Optimize video for YouTube before upload
+ffmpeg -i input.mp4 \
+  -c:v libx264 \
+  -preset slow \
+  -crf 22 \
+  -c:a aac \
+  -b:a 192k \
+  -movflags +faststart \
+  -maxrate 8000k \
+  -bufsize 12000k \
+  youtube_optimized.mp4
+
+# Upload optimized video
+claude-studio upload youtube youtube_optimized.mp4 -t "My Video"
+```
+
+### Metadata Strategy
+
+#### Title Optimization
+- Include primary keywords early
+- Keep under 60 characters for full visibility
+- Use descriptive, compelling language
+- Avoid excessive capitalization or symbols
+
+#### Description Best Practices
+- Start with hook in first 125 characters
+- Include relevant keywords naturally
+- Add timestamps for longer videos
+- Include links to related content
+- Use line breaks for readability
+
+#### Tag Strategy
+- Use specific, relevant tags
+- Include variations and synonyms
+- Mix broad and specific tags
+- Avoid misleading tags
+
+### Privacy Settings
+
+#### Content Strategy
+- **Private**: For internal review and testing
+- **Unlisted**: For sharing with specific audiences
+- **Public**: For maximum reach and discoverability
+
+#### Gradual Rollout
+```bash
+# Initial upload as unlisted
+claude-studio upload youtube video.mp4 -t "My Video" --privacy unlisted
+
+# Review and test sharing
+
+# Make public when ready
+claude-studio upload youtube-update VIDEO_ID --privacy public --notify
+```
+
+## Advanced Features
+
+### Custom Thumbnails
+While the CLI doesn't directly support thumbnail upload, you can:
+
+1. Upload video via CLI
+2. Use YouTube Studio web interface for thumbnail
+3. Or use YouTube Data API directly for programmatic thumbnail upload
+
+### Playlists and Channels
+Future versions may include:
+- Playlist creation and management
+- Channel branding integration
+- Community tab posting
+- Live streaming support
+
+### Analytics Integration
+Consider integrating with:
+- YouTube Analytics API for performance tracking
+- Google Analytics for deeper insights
+- Custom reporting dashboards
+
+## Version History
+
+- **0.6.0**: YouTube OAuth2 integration with metadata management
+- **0.5.x**: Basic YouTube upload functionality
+- **0.4.x**: Platform upload framework

--- a/docs/cli/utilities.md
+++ b/docs/cli/utilities.md
@@ -163,21 +163,3 @@ cs luma recover -o ./recovered -n 100
 | `status` | `GENERATION_ID`, `--json` | Show generation status |
 | `download` | `GENERATION_ID`, `-o PATH` | Download a generation |
 | `recover` | `-o DIR`, `-n LIMIT`, `--dry-run` | Recover completed generations |
-
----
-
-## Combine (`cs combine`)
-
-Combine scene videos from a production run.
-
-```bash
-cs combine <run_id> -l              # List available scenes
-cs combine <run_id> -s 1,3,4        # Combine specific scenes
-cs combine <run_id> -o combined.mp4 # Custom output filename
-```
-
-| Option | Description |
-|--------|-------------|
-| `-s`, `--scenes` | Comma-separated scene numbers to combine |
-| `-o`, `--output` | Output filename |
-| `-l`, `--list` | List available scenes without combining |

--- a/docs/cli/utilities.md
+++ b/docs/cli/utilities.md
@@ -1,0 +1,183 @@
+# Utility Commands
+
+Reference for status, config, secrets, themes, memory, QA, agents, Luma, and combine commands.
+
+---
+
+## Status (`cs status`)
+
+Show system status — config, providers, API keys, environment.
+
+```bash
+cs status
+cs status --json
+```
+
+| Option | Description |
+|--------|-------------|
+| `--json` | Output as JSON |
+
+---
+
+## Config (`cs config`)
+
+Manage configuration.
+
+```bash
+cs config show       # Display current configuration
+cs config validate   # Validate config files
+cs config init       # Create initial .env file
+cs config init -f    # Overwrite existing .env
+```
+
+| Command | Description |
+|---------|-------------|
+| `show` | Display current configuration |
+| `validate` | Validate config files |
+| `init` | Create initial .env file (`-f` to overwrite) |
+
+---
+
+## Secrets (`cs secrets`)
+
+Secure API key management using OS keychain.
+
+```bash
+cs secrets list                          # List stored keys
+cs secrets set ELEVENLABS_API_KEY        # Set key (prompts for value)
+cs secrets set OPENAI_API_KEY -v sk-...  # Set key with value
+cs secrets delete LUMA_API_KEY           # Delete a key
+cs secrets delete LUMA_API_KEY -f        # Delete without confirmation
+cs secrets import .env                   # Import keys from .env file
+cs secrets import .env --delete-after    # Import and delete .env
+cs secrets check                         # Check keychain backend status
+```
+
+| Command | Options | Description |
+|---------|---------|-------------|
+| `list` | | List all stored API keys |
+| `set` | `KEY_NAME`, `-v VALUE` | Store an API key |
+| `delete` | `KEY_NAME`, `-f` | Remove an API key |
+| `import` | `ENV_FILE`, `--delete-after` | Import from .env file |
+| `check` | | Check keychain backend |
+
+---
+
+## Themes (`cs themes`)
+
+List and preview color themes for CLI output.
+
+```bash
+cs themes -l           # List all themes
+cs themes -p           # Preview all themes
+cs themes monokai -p   # Preview specific theme
+```
+
+| Option | Description |
+|--------|-------------|
+| `-l`, `--list` | List available themes |
+| `-p`, `--preview` | Preview a theme |
+| `THEME_NAME` | Optional theme to show/preview |
+
+---
+
+## Memory (`cs memory`)
+
+Memory and learnings management (multi-tenant, multi-backend).
+
+```bash
+cs memory stats
+cs memory list
+cs memory list luma -l session -n 50
+cs memory search "video quality tips"
+```
+
+**Global Options:**
+| Option | Env Var | Description |
+|--------|---------|-------------|
+| `-o`, `--org` | `CLAUDE_STUDIO_ORG_ID` | Organization ID (default: local) |
+| `-a`, `--actor` | `CLAUDE_STUDIO_ACTOR_ID` | Actor/user ID (default: dev) |
+| `-b`, `--backend` | `MEMORY_BACKEND` | Memory backend (local or hosted) |
+
+| Command | Options | Description |
+|---------|---------|-------------|
+| `stats` | `--json` | Show memory statistics |
+| `list` | `PROVIDER`, `-l LEVEL`, `-n LIMIT`, `--json` | List memory records |
+| `search` | `QUERY`, `-p PROVIDER`, `-n LIMIT`, `--json` | Search memories |
+
+---
+
+## QA (`cs qa`)
+
+Inspect quality scores from production runs.
+
+```bash
+cs qa show <run_id>
+cs qa show <run_id> -s scene_001
+cs qa show <run_id> -v
+cs qa show <run_id> --json
+```
+
+| Option | Description |
+|--------|-------------|
+| `-s`, `--scene` | Filter to a specific scene ID |
+| `-v`, `--verbose` | Show frame-by-frame breakdown |
+| `--json` | Output raw JSON |
+
+---
+
+## Agents (`cs agents`)
+
+List and inspect agent configurations.
+
+```bash
+cs agents list
+cs agents list --json
+cs agents schema <agent_name>
+```
+
+| Command | Options | Description |
+|---------|---------|-------------|
+| `list` | `--json` | List all agents |
+| `schema` | `NAME` | Show agent schema |
+
+---
+
+## Luma (`cs luma`)
+
+Luma API management — list generations, check status, download, and recover videos.
+
+```bash
+cs luma list
+cs luma list -n 20 -s completed --json
+cs luma status <generation_id>
+cs luma download <generation_id>
+cs luma download <generation_id> -o output.mp4
+cs luma recover --dry-run
+cs luma recover -o ./recovered -n 100
+```
+
+| Command | Options | Description |
+|---------|---------|-------------|
+| `list` | `-n LIMIT`, `-s STATE`, `--json` | List generations (state: all/completed/failed/pending) |
+| `status` | `GENERATION_ID`, `--json` | Show generation status |
+| `download` | `GENERATION_ID`, `-o PATH` | Download a generation |
+| `recover` | `-o DIR`, `-n LIMIT`, `--dry-run` | Recover completed generations |
+
+---
+
+## Combine (`cs combine`)
+
+Combine scene videos from a production run.
+
+```bash
+cs combine <run_id> -l              # List available scenes
+cs combine <run_id> -s 1,3,4        # Combine specific scenes
+cs combine <run_id> -o combined.mp4 # Custom output filename
+```
+
+| Option | Description |
+|--------|-------------|
+| `-s`, `--scenes` | Comma-separated scene numbers to combine |
+| `-o`, `--output` | Output filename |
+| `-l`, `--list` | List available scenes without combining |


### PR DESCRIPTION
Complete CLI documentation covering all 20+ commands with usage, options, examples, and tips.

## Files
- `docs/cli/README.md` — Overview and quick reference table
- `docs/cli/produce.md` — Full production pipeline
- `docs/cli/produce-video.md` — Explainer video from scripts
- `docs/cli/assemble.md` — Rough cut assembly
- `docs/cli/assets.md` — Asset tracking/approval
- `docs/cli/resume.md` — Resume interrupted productions
- `docs/cli/render.md` — Render, mix, EDL
- `docs/cli/kb.md` — Knowledge base (create, add, inspect, script, produce)
- `docs/cli/document.md` — Document ingestion
- `docs/cli/upload.md` — YouTube upload, update, auth
- `docs/cli/training.md` — Podcast calibration pipeline
- `docs/cli/providers.md` — Provider management and testing
- `docs/cli/utilities.md` — Status, config, secrets, themes, memory, QA, agents, luma, combine

Generated from source code analysis of all CLI modules.