### PR TITLE
fix(deps): one spiritwriter git dependency with the correct name

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "spiritwriter>=0.9.0",  # shared KB pipeline (models in 0.9.0; bump floor as later steps consume newer modules)
+    "spiritwriter @ git+https://github.com/aaronmarkham/spiritwriter-core.git",  # shared KB pipeline; git dep tracks main during the migration (avoids a PyPI release per step)
     "anthropic>=0.34.0",
     "strands-agents>=0.1.0",
     "aiohttp>=3.9.0",
@@ -50,7 +50,6 @@ dependencies = [
     "textstat>=0.7.0",
     "numpy>=1.24.0",
     "pymupdf>=1.24.0",
-    "spiritwriter-core @ git+https://github.com/aaronmarkham/spiritwriter-core.git",
     "Pillow>=10.0.0",
 ]
 


### PR DESCRIPTION
main carried two conflicting spiritwriter requirements: the PyPI floor `spiritwriter>=0.9.0` and a git dep named `spiritwriter-core`. Problems: (1) the git dep's name didn't match the built package (`spiritwriter`), so a fresh install errors on a direct-reference name mismatch; (2) a version-spec + a direct reference for the same package is a double-requirement pip rejects.

Consolidated to a single git dependency:
```
spiritwriter @ git+https://github.com/aaronmarkham/spiritwriter-core.git
```
Verified with `pip install --dry-run --no-deps` → `Would install spiritwriter-0.9.1`.

The git dep tracks `main`, so CSP picks up spiritwriter changes during the migration **without a PyPI release per step** — which dissolves the version-gate cadence we'd planned around (see #15). Pin a tag (`@v0.9.1`) later if you want reproducible installs once things stabilize.
