### PR TITLE
port(kb): delegate duplicated KB helpers to spiritwriter (#15)

### DIFF
--- a/cli/kb.py
+++ b/cli/kb.py
@@ -25,200 +25,37 @@ console = Console()
 
 KB_DIR = Path("artifacts") / "kb"
 
-
-def _resolve_project(project: str) -> Optional[Path]:
-    """Resolve a project identifier to its directory.
-
-    Tries: exact dir name, prefix match on ID, name match in project.json.
-    """
-    if not KB_DIR.exists():
-        return None
-
-    # Exact match
-    exact = KB_DIR / project
-    if exact.is_dir():
-        return exact
-
-    # Prefix match on directory name (also check without kb_ prefix)
-    for d in KB_DIR.iterdir():
-        if d.is_dir() and (d.name.startswith(project) or d.name == f"kb_{project}"):
-            return d
-
-    # Name match (case-insensitive) via project.json
-    for d in KB_DIR.iterdir():
-        if not d.is_dir():
-            continue
-        meta_path = d / "project.json"
-        if meta_path.exists():
-            try:
-                with open(meta_path, encoding="utf-8") as f:
-                    meta = json.load(f)
-                if meta.get("name", "").lower() == project.lower():
-                    return d
-            except (json.JSONDecodeError, OSError):
-                continue
-
-    return None
+# KB logic consolidated into spiritwriter (claude-studio-producer#15 /
+# spiritwriter-core#76). Thin wrappers keep the local names + behavior
+# (KB_DIR binding, has_knowledge_graph flag) while delegating to spiritwriter.kb.
+from spiritwriter.kb import (
+    resolve_project as _sw_resolve_project,
+    load_project as _load_project,
+    save_project as _save_project,
+    rebuild_knowledge_graph as _sw_rebuild_knowledge_graph,
+    build_concept_from_kb as _build_concept_from_kb,
+    calculate_topic_quality as _calculate_topic_quality,
+    calculate_entity_quality as _calculate_entity_quality,
+    get_atom_type_distribution as _get_atom_type_distribution,
+    STRUCTURAL_NOISE_TERMS,
+)
 
 
-def _load_project(project_dir: Path):
-    """Load a KnowledgeProject from its directory"""
-    from core.models.knowledge import KnowledgeProject
-
-    meta_path = project_dir / "project.json"
-    with open(meta_path, encoding="utf-8") as f:
-        data = json.load(f)
-    return KnowledgeProject.from_dict(data)
+def _resolve_project(project):
+    return _sw_resolve_project(project, KB_DIR)
 
 
-def _save_project(project_dir: Path, project):
-    """Save a KnowledgeProject to its directory"""
-    meta_path = project_dir / "project.json"
-    with open(meta_path, "w", encoding="utf-8") as f:
-        json.dump(project.to_dict(), f, indent=2, ensure_ascii=False)
-
-
-def _rebuild_knowledge_graph(project_dir: Path, project) -> None:
-    """Rebuild the unified KnowledgeGraph from all source DocumentGraphs.
-
-    Merges atoms, builds topic/entity indices, detects cross-source links
-    by shared entity co-occurrence.
-    """
-    from core.models.knowledge import KnowledgeGraph, CrossSourceLink
-    from core.models.document import DocumentAtom, AtomType
-
-    all_atoms: Dict[str, DocumentAtom] = {}
-    atom_sources: Dict[str, str] = {}
-    topic_index: Dict[str, List[str]] = {}
-    entity_index: Dict[str, List[str]] = {}
-
-    sources_dir = project_dir / "sources"
-
-    for source_id, source in project.sources.items():
-        graph_path = sources_dir / source_id / "document_graph.json"
-        if not graph_path.exists():
-            continue
-
-        with open(graph_path, encoding="utf-8") as f:
-            graph_data = json.load(f)
-
-        for atom_id, atom_data in graph_data.get("atoms", {}).items():
-            atom = DocumentAtom(
-                atom_id=atom_data["atom_id"],
-                atom_type=AtomType(atom_data["atom_type"]),
-                content=atom_data.get("content", ""),
-                source_page=atom_data.get("source_page"),
-                source_location=atom_data.get("source_location"),
-                topics=atom_data.get("topics", []),
-                entities=atom_data.get("entities", []),
-                relationships=atom_data.get("relationships", []),
-                importance_score=atom_data.get("importance_score", 0.5),
-                caption=atom_data.get("caption"),
-                figure_number=atom_data.get("figure_number"),
-                data_summary=atom_data.get("data_summary"),
-            )
-            all_atoms[atom_id] = atom
-            atom_sources[atom_id] = source_id
-
-            # Build topic index
-            for topic in atom.topics:
-                if topic not in topic_index:
-                    topic_index[topic] = []
-                topic_index[topic].append(atom_id)
-
-            # Build entity index
-            for entity in atom.entities:
-                if entity not in entity_index:
-                    entity_index[entity] = []
-                entity_index[entity].append(atom_id)
-
-    # Detect cross-source links via shared entities
-    cross_links: List[CrossSourceLink] = []
-    link_counter = 0
-
-    for entity, atom_ids in entity_index.items():
-        # Get unique sources for this entity
-        sources_with_entity = {}
-        for aid in atom_ids:
-            sid = atom_sources.get(aid)
-            if sid:
-                if sid not in sources_with_entity:
-                    sources_with_entity[sid] = []
-                sources_with_entity[sid].append(aid)
-
-        # If entity appears in 2+ sources, create cross-links
-        source_ids = list(sources_with_entity.keys())
-        if len(source_ids) >= 2:
-            for i in range(len(source_ids) - 1):
-                for j in range(i + 1, len(source_ids)):
-                    # Link first atom from each source
-                    src_a = source_ids[i]
-                    src_b = source_ids[j]
-                    atom_a = sources_with_entity[src_a][0]
-                    atom_b = sources_with_entity[src_b][0]
-
-                    link_counter += 1
-                    cross_links.append(CrossSourceLink(
-                        link_id=f"link_{link_counter:04d}",
-                        source_atom_id=atom_a,
-                        target_atom_id=atom_b,
-                        source_source_id=src_a,
-                        target_source_id=src_b,
-                        relationship="same_topic",
-                        confidence=0.6,
-                        created_by="auto",
-                    ))
-
-    # Identify key themes (topics appearing in most sources, filtering noise)
-    source_count = len(project.sources)
-    key_themes = []
-    # Stopwords that shouldn't be standalone themes
-    theme_stopwords = {
-        "this", "that", "with", "from", "have", "been", "their", "which",
-        "also", "more", "than", "into", "each", "such", "only", "other",
-        "some", "these", "those", "over", "many", "most", "both", "does",
-        "used", "using", "based", "however", "results", "experimental",
-        "international", "introduction", "related", "conclusion", "nature",
-        "conference", "proceedings", "references", "abstract", "proposed",
-        "machine", "neural", "network", "networks", "learning", "training",
-        "computer", "vision", "language", "intelligence", "artificial",
-        "analysis", "system", "systems", "performance", "algorithm",
-        "knowledge", "information", "processing", "research",
-    }
-    if source_count > 0:
-        for topic, atom_ids in sorted(topic_index.items(), key=lambda x: -len(x[1])):
-            # Skip stopwords and short single words (keep multi-word topics)
-            if topic.lower() in theme_stopwords:
-                continue
-            # Single words must be at least 6 chars to be meaningful themes
-            if ' ' not in topic and len(topic) < 6:
-                continue
-            # Filter institutional/venue names using content-aware check
-            if not is_theme_candidate(topic):
-                continue
-            topic_sources = set(atom_sources.get(aid) for aid in atom_ids)
-            topic_sources.discard(None)
-            if len(topic_sources) >= min(2, source_count):
-                key_themes.append(topic)
-            if len(key_themes) >= 10:
-                break
-
-    graph = KnowledgeGraph(
-        project_id=project.project_id,
-        atoms=all_atoms,
-        atom_sources=atom_sources,
-        cross_links=cross_links,
-        topic_index=topic_index,
-        entity_index=entity_index,
-        key_themes=key_themes,
-    )
-
-    # Save (exclude raw atom content for large graphs, keep references)
-    graph_path = project_dir / "knowledge_graph.json"
-    with open(graph_path, "w", encoding="utf-8") as f:
-        json.dump(graph.to_dict(), f, indent=2, ensure_ascii=False)
-
+def _rebuild_knowledge_graph(project_dir, project):
+    _sw_rebuild_knowledge_graph(project_dir, project)  # writes knowledge_graph.json
     project.has_knowledge_graph = True
+
+
+
+
+
+
+
+
 
 
 @click.group()
@@ -643,146 +480,6 @@ def remove_cmd(project: str, force: bool):
     console.print(f"[green]Removed project:[/green] {proj.name} ({proj.project_id})")
 
 
-def _build_concept_from_kb(
-    proj: 'KnowledgeProject',
-    kg: 'KnowledgeGraph',
-    prompt: str,
-    source_filter: Optional[List[str]] = None,
-) -> str:
-    """Build a rich concept string from KB content for the production pipeline.
-
-    Assembles structured context from the knowledge graph that the ScriptWriterAgent
-    can use to create an informed, accurate script.
-    """
-    from core.models.document import AtomType
-
-    sections = []
-
-    # Header
-    sections.append(f"KNOWLEDGE BASE: {proj.name}")
-    if proj.description:
-        sections.append(f"DESCRIPTION: {proj.description}")
-
-    # Sources summary
-    source_lines = []
-    for sid, src in proj.sources.items():
-        if source_filter and sid not in source_filter:
-            continue
-        line = f"- {src.title} ({src.source_type.value}, {src.atom_count} atoms)"
-        if src.one_sentence:
-            line += f"\n  Summary: {src.one_sentence}"
-        source_lines.append(line)
-    if source_lines:
-        sections.append("SOURCES:\n" + "\n".join(source_lines))
-
-    # Production direction (user's prompt)
-    sections.append(f"PRODUCTION DIRECTION: {prompt}")
-
-    # Key themes from the knowledge graph
-    if kg.key_themes:
-        themes_clean = [t.replace("\n", " ").replace("\r", "") for t in kg.key_themes]
-        sections.append("KEY THEMES: " + ", ".join(themes_clean))
-
-    # Collect atoms, filtering by source if needed
-    atoms_to_use = []
-    for atom_id, atom in kg.atoms.items():
-        if source_filter:
-            atom_source = kg.atom_sources.get(atom_id, "")
-            if atom_source not in source_filter:
-                continue
-        atoms_to_use.append(atom)
-
-    # Sort by importance (highest first)
-    atoms_to_use.sort(key=lambda a: a.importance_score, reverse=True)
-
-    # Build content sections by type priority
-    char_budget = 4000
-    chars_used = 0
-
-    # 1. Abstracts (full content)
-    abstracts = [a for a in atoms_to_use if a.atom_type == AtomType.ABSTRACT]
-    if abstracts:
-        abstract_lines = []
-        for a in abstracts[:3]:
-            if chars_used + len(a.content) > char_budget:
-                break
-            abstract_lines.append(a.content)
-            chars_used += len(a.content)
-        if abstract_lines:
-            sections.append("ABSTRACTS:\n" + "\n\n".join(abstract_lines))
-
-    # 2. Key quotes
-    quotes = [a for a in atoms_to_use if a.atom_type == AtomType.QUOTE]
-    if quotes:
-        quote_lines = []
-        for a in quotes[:5]:
-            if chars_used + len(a.content) > char_budget:
-                break
-            quote_lines.append(f'"{a.content}"')
-            chars_used += len(a.content)
-        if quote_lines:
-            sections.append("KEY QUOTES:\n" + "\n".join(quote_lines))
-
-    # 3. Section headers (for structure overview)
-    headers = [a for a in atoms_to_use if a.atom_type == AtomType.SECTION_HEADER]
-    if headers:
-        header_texts = [a.content for a in headers[:15]]
-        header_block = ", ".join(header_texts)
-        if chars_used + len(header_block) <= char_budget:
-            sections.append("DOCUMENT STRUCTURE: " + header_block)
-            chars_used += len(header_block)
-
-    # 4. High-importance paragraphs
-    paragraphs = [a for a in atoms_to_use if a.atom_type == AtomType.PARAGRAPH]
-    if paragraphs:
-        para_lines = []
-        for a in paragraphs[:10]:
-            if chars_used >= char_budget:
-                break
-            text = a.content[:300]
-            if len(a.content) > 300:
-                text += "..."
-            para_lines.append(text)
-            chars_used += len(text)
-        if para_lines:
-            sections.append("CONTENT TO COVER:\n" + "\n\n".join(para_lines))
-
-    # 5. Figure descriptions
-    figures = [a for a in atoms_to_use if a.atom_type in (AtomType.FIGURE, AtomType.CHART, AtomType.DIAGRAM)]
-    if figures:
-        fig_lines = []
-        for a in figures[:8]:
-            if chars_used >= char_budget:
-                break
-            desc = a.caption or a.content or f"Figure {a.figure_number or '?'}"
-            fig_lines.append(f"- {desc[:150]}")
-            chars_used += len(desc[:150])
-        if fig_lines:
-            sections.append("FIGURES AVAILABLE:\n" + "\n".join(fig_lines))
-
-    # 6. Entity list for context
-    all_entities = set()
-    for a in atoms_to_use:
-        all_entities.update(a.entities[:3])
-    if all_entities:
-        entity_str = ", ".join(sorted(all_entities)[:20])
-        sections.append(f"KEY ENTITIES: {entity_str}")
-
-    # 7. Cross-source connections
-    if kg.cross_links:
-        link_descs = []
-        for link in kg.cross_links[:5]:
-            src_atom = kg.atoms.get(link.source_atom_id)
-            tgt_atom = kg.atoms.get(link.target_atom_id)
-            if src_atom and tgt_atom:
-                link_descs.append(
-                    f"- {link.relationship}: "
-                    f"{src_atom.content[:60]} <-> {tgt_atom.content[:60]}"
-                )
-        if link_descs:
-            sections.append("CROSS-SOURCE CONNECTIONS:\n" + "\n".join(link_descs))
-
-    return "\n\n".join(sections)
 
 
 @kb_cmd.command("produce")
@@ -922,141 +619,12 @@ def produce_cmd_kb(project, prompt, sources, tier, duration, budget, provider, a
 
 
 # Known structural/noise terms that shouldn't be topics
-STRUCTURAL_NOISE_TERMS = {
-    # Block types (should never be topics)
-    "figure", "figure caption", "caption", "header", "footer",
-    "paragraph", "abstract", "section", "subsection", "title",
-    "table", "equation", "citation", "reference", "bibliography",
-    "author", "date", "keyword", "metadata", "page header", "page footer",
-    # Document structure
-    "volume information", "mathematical expression", "mathematical bracket",
-    "author biography", "affiliations", "contact", "acknowledgments",
-    # Generic academic
-    "introduction", "conclusion", "related work", "background",
-    "methodology", "methods", "results", "discussion", "evaluation",
-    "experimental", "experiment", "future work",
-}
 
 
-def _calculate_topic_quality(topics: Dict[str, List[str]], atom_sources: Dict[str, str]) -> Dict[str, Any]:
-    """Analyze topic quality and detect noise."""
-    total_topics = len(topics)
-    if total_topics == 0:
-        return {"score": 0, "noise_count": 0, "noise_topics": [], "good_topics": []}
-
-    noise_topics = []
-    good_topics = []
-
-    for topic, atom_ids in topics.items():
-        topic_lower = topic.lower().strip()
-
-        # Check for structural noise
-        is_noise = False
-        noise_reason = None
-
-        if topic_lower in STRUCTURAL_NOISE_TERMS:
-            is_noise = True
-            noise_reason = "structural term"
-        elif not is_theme_candidate(topic):
-            # Filters: institutional names, journal/conference names
-            is_noise = True
-            noise_reason = "institutional/venue name"
-        elif len(topic_lower) < 3:
-            is_noise = True
-            noise_reason = "too short"
-        elif topic_lower.isdigit():
-            is_noise = True
-            noise_reason = "numeric only"
-        # Check for single common words
-        elif ' ' not in topic_lower and len(topic_lower) < 6:
-            is_noise = True
-            noise_reason = "short single word"
-
-        if is_noise:
-            noise_topics.append({
-                "topic": topic,
-                "count": len(atom_ids),
-                "reason": noise_reason,
-            })
-        else:
-            # Count sources this topic appears in
-            sources = set(atom_sources.get(aid, "") for aid in atom_ids)
-            sources.discard("")
-            good_topics.append({
-                "topic": topic,
-                "count": len(atom_ids),
-                "sources": len(sources),
-            })
-
-    # Sort by count
-    noise_topics.sort(key=lambda x: x["count"], reverse=True)
-    good_topics.sort(key=lambda x: x["count"], reverse=True)
-
-    # Calculate quality score (0-100)
-    noise_count = len(noise_topics)
-    good_count = len(good_topics)
-    if total_topics > 0:
-        quality_score = int((good_count / total_topics) * 100)
-    else:
-        quality_score = 0
-
-    return {
-        "score": quality_score,
-        "total_topics": total_topics,
-        "noise_count": noise_count,
-        "good_count": good_count,
-        "noise_topics": noise_topics[:20],  # Top 20 noise
-        "good_topics": good_topics[:20],    # Top 20 good
-    }
 
 
-def _calculate_entity_quality(entities: Dict[str, List[str]]) -> Dict[str, Any]:
-    """Analyze entity extraction quality."""
-    total = len(entities)
-    if total == 0:
-        return {"score": 0, "acronyms": [], "proper_names": [], "other": []}
-
-    acronyms = []
-    proper_names = []
-    other = []
-
-    for entity, atom_ids in entities.items():
-        count = len(atom_ids)
-        # Acronyms: all caps, 2-6 chars
-        if entity.isupper() and 2 <= len(entity) <= 6:
-            acronyms.append({"entity": entity, "count": count})
-        # Proper names: capitalized multi-word
-        elif ' ' in entity and entity[0].isupper():
-            proper_names.append({"entity": entity, "count": count})
-        else:
-            other.append({"entity": entity, "count": count})
-
-    # Sort each by count
-    acronyms.sort(key=lambda x: x["count"], reverse=True)
-    proper_names.sort(key=lambda x: x["count"], reverse=True)
-    other.sort(key=lambda x: x["count"], reverse=True)
-
-    # Good entities are acronyms and proper names
-    good_count = len(acronyms) + len(proper_names)
-    quality_score = int((good_count / total) * 100) if total > 0 else 0
-
-    return {
-        "score": quality_score,
-        "total_entities": total,
-        "acronyms": acronyms[:10],
-        "proper_names": proper_names[:10],
-        "other": other[:10],
-    }
 
 
-def _get_atom_type_distribution(atoms: Dict[str, Any]) -> Dict[str, int]:
-    """Count atoms by type."""
-    from core.models.document import AtomType
-    dist = {}
-    for atom in atoms.values():
-        atom_type = atom.atom_type.value if hasattr(atom.atom_type, 'value') else str(atom.atom_type)
-        dist[atom_type] = dist.get(atom_type, 0) + 1
-    return dict(sorted(dist.items(), key=lambda x: -x[1]))
 
 
 @kb_cmd.command("inspect")

--- a/cli/kb.py
+++ b/cli/kb.py
@@ -6,7 +6,7 @@ import asyncio
 import hashlib
 from pathlib import Path
 from datetime import datetime
-from typing import Any, Optional, Dict, List
+from typing import Optional
 
 import click
 from rich.console import Console
@@ -14,20 +14,10 @@ from rich.table import Table
 from rich.panel import Panel
 from rich import box
 
-from core.content_classifier import is_theme_candidate
-
-# Fix Windows encoding issues
-if sys.platform == "win32":
-    sys.stdout.reconfigure(encoding='utf-8', errors='replace')
-    sys.stderr.reconfigure(encoding='utf-8', errors='replace')
-
-console = Console()
-
-KB_DIR = Path("artifacts") / "kb"
-
 # KB logic consolidated into spiritwriter (claude-studio-producer#15 /
-# spiritwriter-core#76). Thin wrappers keep the local names + behavior
-# (KB_DIR binding, has_knowledge_graph flag) while delegating to spiritwriter.kb.
+# spiritwriter-core#76). The duplicated helpers are re-exported under their
+# local names; the two thin wrappers below (near KB_DIR) preserve CSP-specific
+# behavior. spiritwriter.kb is tested in spiritwriter-core's test_kb.py.
 from spiritwriter.kb import (
     resolve_project as _sw_resolve_project,
     load_project as _load_project,
@@ -40,20 +30,27 @@ from spiritwriter.kb import (
     STRUCTURAL_NOISE_TERMS,
 )
 
+# Fix Windows encoding issues
+if sys.platform == "win32":
+    sys.stdout.reconfigure(encoding='utf-8', errors='replace')
+    sys.stderr.reconfigure(encoding='utf-8', errors='replace')
+
+console = Console()
+
+KB_DIR = Path("artifacts") / "kb"
+
 
 def _resolve_project(project):
+    # Wrapper: bind the module's KB_DIR (spiritwriter's resolve_project takes
+    # kb_dir explicitly).
     return _sw_resolve_project(project, KB_DIR)
 
 
 def _rebuild_knowledge_graph(project_dir, project):
-    _sw_rebuild_knowledge_graph(project_dir, project)  # writes knowledge_graph.json
-    project.has_knowledge_graph = True
-
-
-
-
-
-
+    # Wrapper: spiritwriter's rebuild_knowledge_graph writes knowledge_graph.json,
+    # sets project.has_knowledge_graph, and returns the graph. We discard the
+    # return to preserve CSP's None-return contract for this call site.
+    _sw_rebuild_knowledge_graph(project_dir, project)
 
 
 

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -785,6 +785,63 @@ class TestKBCommand:
         assert "Knowledge base" in result.output or "kb" in result.output.lower()
 
 
+class TestKBSpiritwriterDelegation:
+    """Lock the cli.kb -> spiritwriter.kb delegation contract.
+
+    The KB helpers were consolidated into spiritwriter (claude-studio-producer#15
+    / spiritwriter-core#76). The moved logic is tested in spiritwriter-core's
+    test_kb.py; these tests guard the two pieces of CSP-specific glue that have
+    no coverage there: the re-export identities and the two thin wrappers.
+    """
+
+    def test_helpers_are_spiritwriter_reexports(self):
+        import cli.kb as kb
+        import spiritwriter.kb as swkb
+
+        assert kb._load_project is swkb.load_project
+        assert kb._save_project is swkb.save_project
+        assert kb._build_concept_from_kb is swkb.build_concept_from_kb
+        assert kb._calculate_topic_quality is swkb.calculate_topic_quality
+        assert kb._calculate_entity_quality is swkb.calculate_entity_quality
+        assert kb._get_atom_type_distribution is swkb.get_atom_type_distribution
+        assert kb.STRUCTURAL_NOISE_TERMS is swkb.STRUCTURAL_NOISE_TERMS
+
+    def test_resolve_project_binds_kb_dir(self, monkeypatch):
+        import cli.kb as kb
+
+        captured = {}
+
+        def fake_resolve(project, kb_dir):
+            captured["args"] = (project, kb_dir)
+            return "RESOLVED"
+
+        monkeypatch.setattr(kb, "_sw_resolve_project", fake_resolve)
+        result = kb._resolve_project("my-project")
+
+        assert result == "RESOLVED"
+        assert captured["args"] == ("my-project", kb.KB_DIR)
+
+    def test_rebuild_knowledge_graph_returns_none_and_sets_flag(self, monkeypatch):
+        import cli.kb as kb
+
+        class FakeProject:
+            has_knowledge_graph = False
+
+        def fake_rebuild(project_dir, project):
+            # Mirror spiritwriter: sets the flag and returns the graph.
+            project.has_knowledge_graph = True
+            return "GRAPH"
+
+        monkeypatch.setattr(kb, "_sw_rebuild_knowledge_graph", fake_rebuild)
+        proj = FakeProject()
+        result = kb._rebuild_knowledge_graph("proj-dir", proj)
+
+        # Wrapper preserves CSP's None-return contract...
+        assert result is None
+        # ...while the delegated call leaves has_knowledge_graph set.
+        assert proj.has_knowledge_graph is True
+
+
 # ============================================================
 # Provider (Onboarding) Command
 # ============================================================


### PR DESCRIPTION
## Port step 6: kb → spiritwriter (the finish)

Consolidates the **8 duplicated KB helpers** in `cli/kb.py` onto `spiritwriter.kb` — the last line-for-line-duplicated logic in the migration (#15 / spiritwriter-core#76).

## What changed (`cli/kb.py`: 1561 → 1129 lines, −456)
The Click/Rich CLI stays; its command bodies are unchanged. The duplicated helper *definitions* were deleted and replaced with thin delegations to `spiritwriter.kb` (names preserved so every command call site keeps working):

- `_load_project`, `_save_project`, `_build_concept_from_kb`, `_calculate_topic_quality`, `_calculate_entity_quality`, `_get_atom_type_distribution`, `STRUCTURAL_NOISE_TERMS` → direct re-exports (identical signatures).
- `_resolve_project(project)` → wrapper binding the module's `KB_DIR`.
- `_rebuild_knowledge_graph(project_dir, project)` → wrapper that calls spiritwriter's (which writes `knowledge_graph.json` + returns the graph) and preserves CSP's `project.has_knowledge_graph = True` flag.

## Deferred (not duplicated — left in CSP)
The 3 pure-logic blocks still inline in the CLI (DocumentGraph→KnowledgeGraph adapter + per-source sub-graph filter in `inspect`, script dedup-trim in `script`) are **CSP-only, not duplicated**, so they don't need to move for dedup. They're good extraction candidates for the upcoming KB→shard work; tracked there.

## Validation
- All 8 helper names resolve to spiritwriter (`_build_concept_from_kb is spiritwriter.kb.build_concept_from_kb`, etc.); `STRUCTURAL_NOISE_TERMS` = 40 terms.
- `kb --help` exit 0; `TestKBCommand` passes.
- **`kb inspect <real-kb>` runs end-to-end** (Entity Quality 92/100, key themes) — exercises the delegated quality fns + the retained inline blocks together.
- Full unit suite: **826 passed, 6 failed** — the 6 are the pre-existing ffmpeg/youtube env failures; no new failures, no collection errors.

CSP-only (spiritwriter.kb already exists + is tested via `test_kb.py`) — no spiritwriter change needed.
