### PR TITLE
release: 0.8.0 — CLI docs refresh + command coverage post-consolidation

### DIFF
--- a/.claude/commands/produce.md
+++ b/.claude/commands/produce.md
@@ -1,37 +1,58 @@
 # /produce - Run Production Pipeline
 
-Execute the video production pipeline to generate content from a concept.
+Generate a video with the production pipeline. `produce` is now a **command
+group** — pick the subcommand that matches the input, or use `produce-legacy`
+for the classic one-shot concept→video flow.
 
 ## Usage
 
 ```
-/produce "<concept>" [options]
+# New verb-group (pick an input):
+cs produce topic "<topic>"        # research a topic, build a KB, then produce
+cs produce paper <kb_id>          # produce from an existing knowledge base
+cs produce script <file>          # produce from a pre-written script
+cs produce project -c "<prompt>"  # multi-source (shards + KB + assets)
+
+# Classic one-shot concept->video:
+cs produce-legacy -c "<concept>" [options]
 ```
 
 ## Options
 
+### New group (`paper`/`topic`/`script`/`project`)
+- `-p, --provider <name>` - Video provider (`luma`, `higgsfield`, `auto`)
+- `-s, --style <style>` - Video style (`explainer`, `documentary`, `tutorial`)
+- `-d, --duration <seconds>` - Target duration
+- `-b, --budget <amount>` - Budget in USD
+- `-l, --language <code>` - Script/TTS language (ISO 639-1)
+- `--voice <name>` - TTS voice
+- `--live / --mock` - Real providers vs. dry run (mock)
+
+### Legacy (`produce-legacy`)
+- `-c, --concept <text>` - Concept description (required)
 - `--budget <amount>` - Budget in USD (determines tier)
-- `--style <style>` - Narrative style (podcast, educational, documentary, visual_storyboard)
-- `--provider <name>` - Video provider (luma, runway, pika)
+- `--style <style>` - Narrative style (`visual_storyboard`, `podcast`, `educational`, `documentary`)
+- `--provider <name>` - Video provider (`luma`, `runway`, `mock`)
+- `--audio-tier <tier>` - `none`, `music_only`, `simple_overlay`, `time_synced`
+- `--mode <mode>` - `video-led` or `audio-led`
 - `--live` - Enable live API calls (default is mock mode)
-- `--scenes <n>` - Override number of scenes
 
 ## Examples
 
 ```bash
-# Mock mode test
-/produce "A day in the life of a bee" --budget 5
+# Mock-mode test, research a topic end-to-end
+cs produce topic "A day in the life of a bee" --budget 5
 
-# Live production with podcast style
-/produce "The science of coffee brewing" --budget 20 --style podcast --live
+# Produce from a knowledge base, live
+cs produce paper kb_1c28d10264bd --budget 20 --live -p luma
 
-# Using specific provider
-/produce "Abstract art in motion" --budget 10 --provider runway --live
+# Classic concept->video, podcast narration, live
+cs produce-legacy -c "The science of coffee brewing" --budget 20 --style podcast --live
 ```
 
 ## What It Does
 
-1. Producer agent analyzes concept and budget
+1. Producer agent analyzes concept/inputs and budget
 2. ScriptWriter creates scene breakdown
 3. VideoGenerator generates each scene
 4. AudioGenerator creates narration
@@ -40,29 +61,16 @@ Execute the video production pipeline to generate content from a concept.
 7. Editor creates edit decision list
 8. Renderer combines into final output
 
-## Production Tiers
-
-| Budget | Tier | Resolution | Duration |
-|--------|------|------------|----------|
-| $1-5 | Micro | 720p | 15-30s |
-| $5-20 | Standard | 1080p | 30-90s |
-| $20-50 | Premium | 1080p | 90-180s |
-| $50+ | Pro | 4K | 180s+ |
-
 ## Output
 
-- Video saved to `artifacts/runs/<run_id>/output.mp4`
+- Video saved to `artifacts/runs/<run_id>/`
 - Scene files in `artifacts/runs/<run_id>/scenes/`
-- Script in `artifacts/runs/<run_id>/script.json`
 - Learnings saved to memory
 
-## Skills Used
-
-This command activates:
-- `video-production` skill for rendering patterns
-- `provider-integration` skill for API calls
-- `podcast-profile` skill (if --style podcast)
+Check or resume a run with `cs produce status <run_id>` / `cs produce resume <run_id>`.
 
 ## Cost
 
 Estimated cost shown before live execution. Mock mode has no API costs.
+
+See `docs/cli/produce.md` and `docs/cli/produce-legacy.md` for the full reference.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,26 @@
 
 ## [Unreleased]
 
+## [0.8.0] - 2026-06-17
+
+The knowledge-base pipeline is now sourced entirely from **spiritwriter** instead of duplicated in this repo. Over a six-step lift-and-shift consume-back migration (#15), CSP's copies of the KB models, JSON extractor, content classifier, LLM client, document ingestor, and `kb` helpers were deleted and replaced with thin shims/adapters/delegations over `spiritwriter`. CSP now depends on spiritwriter via a single git dependency; ~3,600 lines of duplicated code were removed. No user-facing behavior changed (the CSP test suite validates each step against the consolidated code), except the default-model bump noted below.
+
 ### Changed
 - **LLM model default**: `ClaudeClient` now defaults to `claude-sonnet-4-6` (was the older `claude-sonnet-4-20250514`). This is a live behavior change for every call site that doesn't pass an explicit `model=`. Pin a model per call if you depend on the previous default.
-- **`ClaudeClient` consolidated onto spiritwriter**: `core/claude_client.py` is now a thin re-export of spiritwriter's `AnthropicProvider` (aliased `ClaudeClient`) plus `JSONExtractor`. The local implementation was deleted. The public API is a backward-compatible superset (`query`, `query_with_image`/`image_path=`, `query_with_images`, `return_usage`, `system_prompt` all unchanged). Keychain resolution stays on the `claude-studio` service. (#19 / #15)
+- **KB pipeline consolidated onto spiritwriter** — CSP now imports each piece from `spiritwriter` and deleted its local copy (paired with spiritwriter-core's releases up to 0.10.0):
+  - `core/models/{document,knowledge}.py` → re-export shims over `spiritwriter.models` (#16)
+  - `JSONExtractor` → from `spiritwriter.llm.anthropic` (#17)
+  - `core/content_classifier.py` → shim over `spiritwriter.classify`; `core/secrets` migrated too (#15)
+  - `core/claude_client.py` → thin re-export of `spiritwriter`'s `AnthropicProvider` (aliased `ClaudeClient`) + `JSONExtractor`; local implementation deleted. Public API is a backward-compatible superset (`query`, `query_with_image`/`image_path=`, `query_with_images`, `return_usage`, `system_prompt`). Keychain resolution stays on the `claude-studio` service. (#19)
+  - `agents/document_ingestor.py` → `DocumentIngestorAgent(StudioAgent, DocumentIngestor)` adapter; ~1000 lines removed (#20)
+  - `cli/kb.py` → its 8 duplicated KB helpers delegate to `spiritwriter.kb`; Click CLI unchanged (#22)
+- **`--version` now reads from package metadata** instead of a hardcoded string, so it can't drift from `pyproject.toml` (it was stuck at `0.7.0`).
+
+### Fixed
+- Cleaned up 10 stale `produce` CLI tests left over from the `produce` → subcommand-group refactor (the old command is now `produce-legacy`); the unit suite is green except pre-existing ffmpeg/youtube env failures. (#21)
+
+### Documentation
+- Refreshed the CLI docs for the `produce` command group. The old monolithic `produce -c CONCEPT` is now `produce-legacy`, and `produce` is a group of input-specific subcommands (`paper`, `topic`, `script`, `project`, `status`, `resume`, `list`, `edit`). Rewrote `docs/cli/produce.md`, added `docs/cli/produce-legacy.md`, and corrected the in-code `--help` text, README, and CLI reference index.
 
 ## [0.7.0] - 2026-02-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+_Nothing yet._
+
 ## [0.8.0] - 2026-06-17
 
 The knowledge-base pipeline is now sourced entirely from **spiritwriter** instead of duplicated in this repo. Over a six-step lift-and-shift consume-back migration (#15), CSP's copies of the KB models, JSON extractor, content classifier, LLM client, document ingestor, and `kb` helpers were deleted and replaced with thin shims/adapters/delegations over `spiritwriter`. CSP now depends on spiritwriter via a single git dependency; ~3,600 lines of duplicated code were removed. No user-facing behavior changed (the CSP test suite validates each step against the consolidated code), except the default-model bump noted below.
@@ -15,7 +17,7 @@ The knowledge-base pipeline is now sourced entirely from **spiritwriter** instea
   - `core/claude_client.py` → thin re-export of `spiritwriter`'s `AnthropicProvider` (aliased `ClaudeClient`) + `JSONExtractor`; local implementation deleted. Public API is a backward-compatible superset (`query`, `query_with_image`/`image_path=`, `query_with_images`, `return_usage`, `system_prompt`). Keychain resolution stays on the `claude-studio` service. (#19)
   - `agents/document_ingestor.py` → `DocumentIngestorAgent(StudioAgent, DocumentIngestor)` adapter; ~1000 lines removed (#20)
   - `cli/kb.py` → its 8 duplicated KB helpers delegate to `spiritwriter.kb`; Click CLI unchanged (#22)
-- **`--version` now reads from package metadata** instead of a hardcoded string, so it can't drift from `pyproject.toml` (it was stuck at `0.7.0`).
+- **`--version` now reads from a single in-package version module** (`cli/_version.py`) that `pyproject.toml` also derives its version from, so the two can't drift. Previously `--version` was a hardcoded string (stuck at `0.7.0`), separate from `pyproject`; reading `importlib.metadata` instead would have returned a stale `0.6.0` in editable installs, so the in-package module is the source of truth.
 
 ### Fixed
 - Cleaned up 10 stale `produce` CLI tests left over from the `produce` → subcommand-group refactor (the old command is now `produce-legacy`); the unit suite is green except pre-existing ffmpeg/youtube env failures. (#21)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,14 +57,15 @@ artifacts/        # Run outputs, memory.json, training_output/
 ## Common Commands
 
 ```bash
-# Production (mock mode - no API costs)
-python -m cli.produce "concept" --budget 5
+# Production — `produce` is a command group; pick an input subcommand:
+cs produce topic "concept" --budget 5            # research a topic -> KB -> video (mock)
+cs produce paper <kb_id> --budget 5 --live -p luma  # from an existing KB, live
+cs produce script myscript.txt --budget 5        # from a pre-written script
 
-# Live mode with real generation
-python -m cli.produce "concept" --budget 5 --live --provider luma
-
-# With narrative style
-python -m cli.produce "concept" --style podcast  # or: educational, documentary, visual_storyboard
+# Classic one-shot concept->video (the old `produce`, now `produce-legacy`)
+cs produce-legacy -c "concept" --budget 5
+cs produce-legacy -c "concept" --budget 5 --live --provider luma
+cs produce-legacy -c "concept" --style podcast   # or: educational, documentary, visual_storyboard
 
 # Knowledge base
 claude-studio kb create "Project" -d "Description"

--- a/README.md
+++ b/README.md
@@ -69,11 +69,18 @@ cp .env.example .env
 # Add ANTHROPIC_API_KEY and LUMA_API_KEY
 
 # Run a production (mock mode - no API costs)
-claude-studio produce "A serene mountain lake at sunset" --budget 5
+claude-studio produce topic "A serene mountain lake at sunset" --budget 5
 
 # Run with real video generation
-claude-studio produce "A serene mountain lake at sunset" --budget 5 --live --provider luma
+claude-studio produce topic "A serene mountain lake at sunset" --budget 5 --live --provider luma
+
+# Prefer the classic one-shot concept->video flow?
+claude-studio produce-legacy -c "A serene mountain lake at sunset" --budget 5
 ```
+
+> `produce` is a command group — pick an input subcommand (`topic`, `paper`,
+> `script`, `project`). The old single-command `produce -c "concept"` flow is
+> now `produce-legacy`. See [docs/cli/produce.md](docs/cli/produce.md).
 
 ## Architecture
 
@@ -178,14 +185,14 @@ PROVIDER LEARNING LIFECYCLE
 ### CLI with Live Progress
 
 ```bash
-# Basic production
-python -m cli.produce "Product demo for mobile app" --budget 10
+# Basic production (classic one-shot concept->video)
+cs produce-legacy -c "Product demo for mobile app" --budget 10
 
-# With seed image (image-to-video)
-python -m cli.produce "Animate this logo" --budget 5 --seed logo.png
+# With seed images (image-to-video) — point at a directory of PNG/JPG
+cs produce-legacy -c "Animate this logo" --budget 5 --seed-assets ./logo_assets/
 
 # Live mode with real generation
-python -m cli.produce "Tech startup intro" --budget 15 --live --provider luma
+cs produce-legacy -c "Tech startup intro" --budget 15 --live --provider luma
 ```
 
 The CLI shows:
@@ -288,16 +295,16 @@ Control how verbose and conversational your scripts are:
 
 ```bash
 # Brief visual storyboard (default) - ~20-30 words per scene
-claude-studio produce -c "Product demo" --style visual_storyboard
+claude-studio produce-legacy -c "Product demo" --style visual_storyboard
 
 # Rich podcast narrative (NotebookLM-style) - ~100 words per scene
-claude-studio produce -c "Explain quantum computing" --style podcast
+claude-studio produce-legacy -c "Explain quantum computing" --style podcast
 
 # Educational lecture format - ~80-120 words per scene
-claude-studio produce -c "Tutorial on React hooks" --style educational
+claude-studio produce-legacy -c "Tutorial on React hooks" --style educational
 
 # Documentary with gravitas - ~60-100 words per scene
-claude-studio produce -c "History of the internet" --style documentary
+claude-studio produce-legacy -c "History of the internet" --style documentary
 ```
 
 | Style | Words/Scene | Best For |
@@ -373,10 +380,10 @@ In audio-led mode, the audio narration drives the timeline. Videos are generated
 
 ```bash
 # Audio-led production (auto-detected from style)
-claude-studio produce "Explain quantum computing" --style podcast --budget 5 --live
+claude-studio produce-legacy -c "Explain quantum computing" --style podcast --budget 5 --live
 
 # Or explicitly set mode
-claude-studio produce "Tutorial on Python decorators" --mode audio-led --budget 5 --live
+claude-studio produce-legacy -c "Tutorial on Python decorators" --mode audio-led --budget 5 --live
 ```
 
 #### Video-Led Production (Visual Storyboard, Cinematic)
@@ -387,7 +394,7 @@ In video-led mode, the video drives the timeline. Audio is generated to match vi
 
 ```bash
 # Video-led production (default for visual styles)
-claude-studio produce "Cinematic coffee commercial" --style visual_storyboard --budget 5 --live
+claude-studio produce-legacy -c "Cinematic coffee commercial" --style visual_storyboard --budget 5 --live
 ```
 
 #### Automatic Audio-Video Mixing

--- a/cli/__init__.py
+++ b/cli/__init__.py
@@ -2,6 +2,7 @@
 
 import click
 from dotenv import load_dotenv
+from ._version import __version__
 from .status import status_cmd
 from .providers import providers_cmd
 from .agents import agents_cmd
@@ -31,34 +32,53 @@ load_dotenv()
 
 
 @click.group()
-@click.version_option(version="0.7.0")
+@click.version_option(version=__version__)
 def main():
     """Claude Studio Producer - AI Video Production Pipeline
 
     \b
     Quick Start:
-      claude-studio produce -c "Your video concept" --mock
-      claude-studio produce -c "Your video concept" --live -p luma
+      cs produce topic "How to make French press coffee" --mock
+      cs produce paper <kb_id> --live -p luma
+      cs produce script myscript.txt --budget 15
 
     \b
-    Commands:
-      produce        Run full video production pipeline
-      produce-video  Generate explainer video from podcast script
-      assemble       Assemble rough cut video from production run
+    Production (produce is a group — pick an input):
+      produce paper     Produce a video from a knowledge base project
+      produce topic     Research a topic, build a KB, then produce
+      produce script    Produce from a pre-written script file
+      produce project   Multi-source production (shards + KB + assets)
+      produce status    Show status of a production run
+      produce resume    Resume a run from its last checkpoint
+      produce list      List all production runs
+      produce edit      Edit a single scene in a run
+      produce-legacy    Classic one-shot concept->video pipeline (-c CONCEPT)
+      produce-video     Generate explainer video from a podcast script
+
+    \b
+    Post-production & assets:
+      assemble       Assemble a rough cut from a production run
+      figures        Inject/list/remove figures in a run
       assets         Asset tracking and approval workflow
-      resume         Resume a production from where it stopped
       render         Render commands (edl, mix video+audio)
-      test-provider  Test a single provider (quick validation)
-      luma           Luma API management (list, download, recover)
-      memory         Memory and learnings management
-      qa             QA inspection (view quality scores)
+      upload         Upload videos to platforms (YouTube)
+
+    \b
+    Knowledge & inputs:
       document       Document ingestion (PDF to knowledge graph)
       kb             Knowledge base management (multi-source projects)
+      memory         Memory and learnings management
+
+    \b
+    Providers, config & info:
+      test-provider  Test a single provider (quick validation)
       provider       Provider onboarding and management
+      providers      List and manage providers
+      luma           Luma API management (list, download, recover)
       training       Training pipeline for podcast calibration
+      qa             QA inspection (view quality scores)
       secrets        Secure API key management (OS keychain)
       status         Show system status
-      providers      List and manage providers
       agents         List and manage agents
       config         Manage configuration
       themes         List and preview color themes

--- a/cli/_version.py
+++ b/cli/_version.py
@@ -1,0 +1,8 @@
+"""Single source of truth for the package version.
+
+Kept dependency-free so setuptools can read ``__version__`` statically at build
+time (``[tool.setuptools.dynamic]`` in pyproject.toml) and the CLI can import it
+at runtime for ``--version`` — no drift between the two, no reinstall required.
+"""
+
+__version__ = "0.8.0"

--- a/cli/produce.py
+++ b/cli/produce.py
@@ -633,7 +633,10 @@ def produce_cmd(
     """
     Run the full video production pipeline with multi-agent orchestration.
 
-    This command demonstrates sophisticated agent patterns including:
+    This is the classic one-shot concept->video flow, now invoked as
+    `produce-legacy` (the `produce` command is a group — see `cs produce --help`).
+
+    It demonstrates sophisticated agent patterns including:
     - Sequential planning stages (Producer → ScriptWriter)
     - Parallel asset generation (Video + Audio via Strands)
     - Quality evaluation pipeline (QA → Critic → Editor)
@@ -641,22 +644,22 @@ def produce_cmd(
     Examples:
 
         # Quick 5-second demo with mock providers
-        claude-studio produce -c "Logo reveal for TechCorp" -d 5 --mock
+        claude-studio produce-legacy -c "Logo reveal for TechCorp" -d 5 --mock
 
         # Live production with Luma
-        claude-studio produce -c "Product demo for mobile app" -b 15 -d 30 --live -p luma
+        claude-studio produce-legacy -c "Product demo for mobile app" -b 15 -d 30 --live -p luma
 
         # Full production with audio
-        claude-studio produce -c "Tutorial video" -b 50 -d 60 --audio-tier simple_overlay --live
+        claude-studio produce-legacy -c "Tutorial video" -b 50 -d 60 --audio-tier simple_overlay --live
 
         # Use a different color theme
-        claude-studio produce -c "test" --mock --theme matrix
+        claude-studio produce-legacy -c "test" --mock --theme matrix
 
         # Longer timeout for busy Luma queue
-        claude-studio produce -c "My video" --live -p luma --timeout 900
+        claude-studio produce-legacy -c "My video" --live -p luma --timeout 900
 
         # Use seed images for video generation
-        claude-studio produce -c "Product showcase" --live -s ./assets/product_images
+        claude-studio produce-legacy -c "Product showcase" --live -s ./assets/product_images
     """
     # Set theme (from CLI arg or environment variable)
     theme_name = theme or get_default_theme_name()

--- a/docs/cli/README.md
+++ b/docs/cli/README.md
@@ -5,15 +5,21 @@ Complete CLI reference for the AI video production pipeline.
 ## Quick Start
 
 ```bash
-# Quick demo with mock providers
-cs produce -c "Logo reveal for TechCorp" -d 5 --mock
+# Research a topic end-to-end with mock providers
+cs produce topic "How to make French press coffee" --mock
 
-# Live production with Luma
-cs produce -c "Product demo" -b 15 -d 30 --live -p luma
+# Produce from a knowledge base with Luma
+cs produce paper kb_1c28d10264bd -b 15 -d 30 --live -p luma
+
+# Classic one-shot concept->video (legacy command)
+cs produce-legacy -c "Logo reveal for TechCorp" -d 5 --mock
 
 # Generate video from transcript
 cs produce-video --script script.txt --live --kb my-project
 ```
+
+> `produce` is now a **command group** (`paper`, `topic`, `script`, `project`, …).
+> The old one-shot `produce -c "concept"` is now [`produce-legacy`](produce-legacy.md).
 
 ## Command Reference
 
@@ -29,9 +35,11 @@ cs produce-video --script script.txt --live --kb my-project
 
 | Command | Description | Docs |
 |---------|-------------|------|
-| `produce` | Full video production pipeline | [produce.md](produce.md) |
+| `produce` | Production group — `paper`, `topic`, `script`, `project`, `status`, `resume`, `list`, `edit` | [produce.md](produce.md) |
+| `produce-legacy` | Classic one-shot concept→video pipeline (`-c CONCEPT`) | [produce-legacy.md](produce-legacy.md) |
 | `produce-video` | Explainer video from scripts/training | [produce-video.md](produce-video.md) |
 | `assemble` | Rough cut assembly from production assets | [assemble.md](assemble.md) |
+| `figures` | Inject/list/remove figures in a production run | [produce.md](produce.md) |
 | `assets` | Asset tracking and approval workflow | [assets.md](assets.md) |
 | `render` | Render EDLs, mix video+audio | [render.md](render.md) |
 | `resume` | Resume interrupted productions | [resume.md](resume.md) |

--- a/docs/cli/produce-legacy.md
+++ b/docs/cli/produce-legacy.md
@@ -1,0 +1,443 @@
+# produce-legacy - Classic Concept→Video Pipeline
+
+> **Renamed.** This was the original `produce` command. It is now `produce-legacy`;
+> the `produce` name is a command **group** with input-specific subcommands
+> (`paper`, `topic`, `script`, `project`, …). See [produce.md](produce.md). The
+> engine below is unchanged — `produce-legacy` is still a fully supported,
+> one-shot way to go straight from a text concept to a finished video.
+
+The `produce-legacy` command runs the complete AI video production pipeline with multi-agent orchestration from a single concept string. Use it when you just want to hand the pipeline a concept and let it plan, generate, evaluate, and render in one shot.
+
+## Synopsis
+
+```bash
+claude-studio produce-legacy -c CONCEPT [OPTIONS]
+```
+
+## Description
+
+The command demonstrates sophisticated agent patterns including:
+- Sequential planning stages (Producer → ScriptWriter)
+- Parallel asset generation (Video + Audio via Strands)
+- Quality evaluation pipeline (QA → Critic → Editor)
+
+## Required Arguments
+
+### `--concept, -c TEXT`
+Video concept description (required).
+
+**Examples:**
+- `"Logo reveal for TechCorp"`
+- `"Product demo for mobile app"`
+- `"Tutorial on machine learning basics"`
+
+## Options
+
+### Core Options
+
+#### `--budget, -b FLOAT`
+Total budget in USD (default: 10.0).
+
+Controls production scale and provider usage. Higher budgets enable more variations and premium providers.
+
+#### `--duration, -d FLOAT`
+Target video duration in seconds (default: 30.0).
+
+Influences scene count and pacing. Typical ranges:
+- 5-15s: Logo/brand videos
+- 30-60s: Product demos
+- 60-300s: Tutorials/explanations
+
+#### `--provider, -p CHOICE`
+Video provider to use.
+
+**Choices:**
+- `luma` - Luma AI (recommended, text/image to video)
+- `runway` - Runway ML (image to video)
+- `mock` - Mock provider (development/testing)
+
+**Default:** `luma`
+
+### Execution Mode
+
+#### `--live`
+Use live API providers (costs real money!).
+
+When specified, uses actual API providers. **Warning:** Generates real costs.
+
+#### `--mock`
+Use mock providers (default).
+
+Safe development mode with simulated responses and no API costs.
+
+### Production Options
+
+#### `--audio-tier CHOICE`
+Audio production tier.
+
+**Choices:**
+- `none` - No audio generation (default)
+- `music_only` - Background music only
+- `simple_overlay` - Basic voiceover + music
+- `time_synced` - Synchronized audio with video timing
+
+#### `--variations, -v INTEGER`
+Number of video variations per scene (default: 1).
+
+Higher values provide more options but increase cost and generation time.
+
+#### `--timeout INTEGER`
+Video generation timeout in seconds (default: 600).
+
+Increase for busy provider queues or complex generations.
+
+### Advanced Options
+
+#### `--seed-assets, -s PATH`
+Directory containing seed images/assets (PNG/JPG).
+
+Provides reference images for video generation, improving consistency and relevance.
+
+#### `--execution-strategy, -e CHOICE`
+Scene execution strategy for continuity.
+
+**Choices:**
+- `auto` - Automatically detect from script (default)
+- `all_parallel` - Generate all scenes in parallel (fastest)
+- `all_sequential` - Generate scenes sequentially (best continuity)
+- `manual` - Use manual groups from script
+
+#### `--style CHOICE`
+Narrative style.
+
+**Choices:**
+- `visual_storyboard` - Visual-focused narrative (default)
+- `podcast` - Rich NotebookLM-style narration
+- `educational` - Educational lecture format
+- `documentary` - Documentary style
+
+#### `--mode CHOICE`
+Production mode.
+
+**Choices:**
+- `video-led` - Video determines timing (default)
+- `audio-led` - Audio determines timing
+
+### Output Options
+
+#### `--output-dir, -o PATH`
+Output directory.
+
+**Default:** `artifacts/runs/<run_id>`
+
+#### `--run-id TEXT`
+Custom run ID.
+
+**Default:** Auto-generated timestamp (`YYYYMMDD_HHMMSS`)
+
+### Display Options
+
+#### `--verbose, -V`
+Show full artifacts without truncation.
+
+Displays complete scene descriptions, prompts, and evaluation details.
+
+#### `--theme, -t TEXT`
+Color theme.
+
+**Choices:** `default`, `ocean`, `sunset`, `matrix`, `pro`, `neon`, `mono`
+
+#### `--json`
+Output results as JSON.
+
+Suppresses rich formatting and returns structured data.
+
+#### `--debug`
+Enable debug output.
+
+Shows detailed error traces and internal processing information.
+
+## Examples
+
+### Basic Usage
+
+```bash
+# Quick 5-second demo with mock providers
+claude-studio produce-legacy -c "Logo reveal for TechCorp" -d 5 --mock
+
+# Live production with Luma (costs money)
+claude-studio produce-legacy -c "Product demo for mobile app" -b 15 -d 30 --live -p luma
+
+# Full production with audio
+claude-studio produce-legacy -c "Tutorial video" -b 50 -d 60 --audio-tier simple_overlay --live
+```
+
+### Advanced Usage
+
+```bash
+# Use seed images for consistent branding
+claude-studio produce-legacy -c "Product showcase" --live -s ./brand_assets/
+
+# Generate multiple variations
+claude-studio produce-legacy -c "Marketing video" -b 30 -v 3 --live
+
+# Extended timeout for complex scenes
+claude-studio produce-legacy -c "Complex animation" --live --timeout 900
+
+# Podcast-style narration
+claude-studio produce-legacy -c "Explain quantum computing" --style podcast --audio-tier time_synced
+
+# Audio-led production (audio timing drives video)
+claude-studio produce-legacy -c "Music video concept" --mode audio-led --audio-tier time_synced
+```
+
+### Output Control
+
+```bash
+# Custom output directory
+claude-studio produce-legacy -c "test" --mock -o ./my_production/
+
+# Custom run ID
+claude-studio produce-legacy -c "test" --mock --run-id my_custom_run
+
+# JSON output for scripting
+claude-studio produce-legacy -c "test" --mock --json > result.json
+
+# Different color theme
+claude-studio produce-legacy -c "test" --mock --theme matrix
+
+# Verbose output with full details
+claude-studio produce-legacy -c "test" --mock --verbose
+```
+
+## Pipeline Stages
+
+### Stage 1: Planning (Sequential)
+
+1. **ProducerAgent** analyzes concept and creates pilot strategies
+   - Budget allocation across production tiers
+   - Provider knowledge from long-term memory
+   - Risk assessment and feasibility analysis
+
+2. **ScriptWriterAgent** generates scene breakdown
+   - Optimal scene count based on duration
+   - Visual elements and transitions
+   - Prompt optimization for selected provider
+
+**Output:** Scene specifications and production plan
+
+### Stage 2: Asset Generation (Parallel via Strands)
+
+1. **VideoGeneratorAgent** creates video content
+   - Uses execution strategy for continuity
+   - Parallel or sequential generation based on dependencies
+   - Seed asset integration when provided
+
+2. **AudioGeneratorAgent** generates voiceover and music (if enabled)
+   - Text-to-speech with selected voice
+   - Background music matching video tone
+   - Timing synchronization with video duration
+
+**Output:** Video clips and audio tracks
+
+### Stage 3: Evaluation (Sequential)
+
+1. **QAVerifierAgent** analyzes video quality
+   - Visual accuracy and coherence
+   - Style consistency across scenes
+   - Technical quality assessment
+   - Narrative fit with original concept
+
+2. **CriticAgent** scores production quality
+   - Overall production evaluation
+   - Budget efficiency analysis
+   - Approval/rejection recommendation
+   - Provider performance learning
+
+3. **EditorAgent** creates Edit Decision Lists (EDLs)
+   - Multiple edit candidate generation
+   - Transition selection and timing
+   - Text overlay positioning
+   - Final assembly instructions
+
+**Output:** Quality scores, approval status, and EDL
+
+### Stage 4: Rendering
+
+1. **AudioMixer** combines video and audio
+   - Fit mode based on production mode
+   - Volume balancing and normalization
+   - Scene concatenation
+
+2. **FFmpegRenderer** creates final video
+   - Transition effects application
+   - Text overlay rendering
+   - Format optimization
+
+**Output:** Final rendered video
+
+## Output Structure
+
+Production runs create organized directory structures:
+
+```
+artifacts/runs/<run_id>/
+├── metadata.json           # Run metadata and costs
+├── scenes/                 # Scene specifications
+│   ├── scene_001.json
+│   ├── scene_002.json
+│   └── ...
+├── videos/                 # Generated video clips
+│   ├── scene_001_v0.mp4
+│   ├── scene_002_v0.mp4
+│   └── ...
+├── audio/                  # Audio files (if enabled)
+│   ├── scene_001_voice.mp3
+│   └── background_music.mp3
+├── edl/                    # Edit Decision Lists
+│   ├── edit_candidates.json
+│   ├── recommended_cut.json
+│   └── ...
+├── renders/                # Final rendered videos
+│   └── final_video.mp4
+├── mixed/                  # Video+audio combinations
+│   └── scene_001_mixed.mp4
+└── final_output.mp4        # Complete final video
+```
+
+## Budget and Cost Management
+
+The pipeline includes sophisticated budget management:
+
+### Production Tiers
+
+Based on budget allocation:
+
+- **Micro** ($0-5): Single scenes, basic quality
+- **Low** ($5-15): Multiple scenes, standard quality
+- **Medium** ($15-50): Enhanced quality, multiple variations
+- **High** ($50-100): Premium quality, extensive variations
+- **Full** ($100+): Maximum quality, comprehensive production
+
+### Cost Tracking
+
+Costs are tracked throughout production:
+
+```json
+{
+  "costs": {
+    "video": 2.50,
+    "audio": 0.15,
+    "total": 2.65
+  },
+  "budget_allocated": 10.00,
+  "budget_spent": 2.65
+}
+```
+
+## Memory and Learning
+
+The pipeline leverages long-term memory for optimization:
+
+### Provider Learning
+- Successful prompt patterns
+- Quality score trends
+- Cost optimization strategies
+- Common failure modes
+
+### Pattern Recognition
+- Scene types that work well
+- Optimal duration ranges
+- Effective transitions
+- Audio-video synchronization
+
+## Error Handling
+
+Common issues and solutions:
+
+### API Configuration
+```bash
+# Missing API keys
+Error: LUMA_API_KEY not set (check keychain or env)
+
+# Solution
+claude-studio secrets set LUMA_API_KEY your_key
+```
+
+### Budget Constraints
+```bash
+# Insufficient budget
+Warning: Concept complexity requires $15+ budget, got $5
+
+# Solution
+claude-studio produce-legacy -c "concept" -b 20 --live
+```
+
+### Generation Failures
+```bash
+# Provider timeout
+Error: Video generation timeout after 600s
+
+# Solution
+claude-studio produce-legacy -c "concept" --timeout 900 --live
+```
+
+### FFmpeg Issues
+```bash
+# Missing FFmpeg
+Warning: FFmpeg not installed - skipping render
+
+# Solution
+brew install ffmpeg  # macOS
+sudo apt install ffmpeg  # Ubuntu
+```
+
+## Integration with Other Commands
+
+### Resume Failed Productions
+```bash
+# If production fails, resume from checkpoint
+claude-studio resume <run_id> --live
+```
+
+### Re-render with Different Settings
+```bash
+# Use existing assets with new edit
+claude-studio render edl <run_id> -c creative_cut
+```
+
+### Upload Results
+```bash
+# Upload final video to YouTube
+claude-studio upload youtube artifacts/runs/<run_id>/final_output.mp4 \
+  -t "My Video Title"
+```
+
+### Asset Management
+```bash
+# Review and approve individual assets
+claude-studio assets list artifacts/runs/<run_id>
+claude-studio assets approve artifacts/runs/<run_id> --image all
+```
+
+## Performance Tips
+
+### Development
+- Use `--mock` flag during development
+- Start with short durations (5-10s)
+- Test concepts with single variations
+
+### Production
+- Set appropriate timeouts for complex scenes
+- Use seed assets for consistency
+- Monitor costs with budget limits
+- Utilize multiple variations for better results
+
+### Optimization
+- Reuse approved assets across runs
+- Leverage provider learning from memory
+- Batch similar productions for efficiency
+
+## See Also
+
+- [produce.md](produce.md) — the current `produce` group (`paper`, `topic`, `script`, `project`), which wraps this same engine behind input-specific entry points.

--- a/docs/cli/produce.md
+++ b/docs/cli/produce.md
@@ -1,439 +1,207 @@
-# produce - Full Video Production Pipeline
+# produce - Video Production Pipeline
 
-The `produce` command runs the complete AI video production pipeline with multi-agent orchestration. This is the main entry point for creating videos from concept descriptions.
-
-## Synopsis
+`produce` is a **command group**. Instead of one monolithic command, you pick the subcommand that matches your **input** — a knowledge base, a topic, a script file, or multiple sources — and the pipeline plans, generates, evaluates, and renders from there.
 
 ```bash
-claude-studio produce -c CONCEPT [OPTIONS]
+cs produce <subcommand> [ARGS] [OPTIONS]
 ```
 
-## Description
+> Looking for the old one-shot `produce -c "concept"` command? It still exists as
+> [`produce-legacy`](produce-legacy.md). The same multi-agent engine
+> (Producer → ScriptWriter → Video/Audio → QA → Critic → Editor → Render)
+> powers both — these subcommands are input-specific front doors to it.
 
-The produce command demonstrates sophisticated agent patterns including:
-- Sequential planning stages (Producer → ScriptWriter)
-- Parallel asset generation (Video + Audio via Strands)
-- Quality evaluation pipeline (QA → Critic → Editor)
+## Subcommands
 
-## Required Arguments
+| Subcommand | Input | Purpose |
+|------------|-------|---------|
+| [`paper`](#produce-paper) | a KB project | Produce a video from an existing knowledge base |
+| [`topic`](#produce-topic) | a topic string | Research the topic, build a KB, then produce |
+| [`script`](#produce-script) | a script file | Produce from a pre-written script |
+| [`project`](#produce-project) | shards + KB + assets | Multi-source production |
+| [`status`](#produce-status) | a run ID | Show status of a run |
+| [`resume`](#produce-resume) | a run ID | Resume a run from its last checkpoint |
+| [`list`](#produce-list) | — | List all production runs |
+| [`edit`](#produce-edit) | a run ID | Edit a single scene in a run |
 
-### `--concept, -c TEXT`
-Video concept description (required).
-
-**Examples:**
-- `"Logo reveal for TechCorp"`
-- `"Product demo for mobile app"`
-- `"Tutorial on machine learning basics"`
-
-## Options
-
-### Core Options
-
-#### `--budget, -b FLOAT`
-Total budget in USD (default: 10.0).
-
-Controls production scale and provider usage. Higher budgets enable more variations and premium providers.
-
-#### `--duration, -d FLOAT` 
-Target video duration in seconds (default: 30.0).
-
-Influences scene count and pacing. Typical ranges:
-- 5-15s: Logo/brand videos
-- 30-60s: Product demos
-- 60-300s: Tutorials/explanations
-
-#### `--provider, -p CHOICE`
-Video provider to use.
-
-**Choices:**
-- `luma` - Luma AI (recommended, text/image to video)
-- `runway` - Runway ML (image to video)  
-- `mock` - Mock provider (development/testing)
-
-**Default:** `luma`
-
-### Execution Mode
-
-#### `--live`
-Use live API providers (costs real money!).
-
-When specified, uses actual API providers. **Warning:** Generates real costs.
-
-#### `--mock` 
-Use mock providers (default).
-
-Safe development mode with simulated responses and no API costs.
-
-### Production Options
-
-#### `--audio-tier CHOICE`
-Audio production tier.
-
-**Choices:**
-- `none` - No audio generation (default)
-- `music_only` - Background music only
-- `simple_overlay` - Basic voiceover + music
-- `time_synced` - Synchronized audio with video timing
-
-#### `--variations, -v INTEGER`
-Number of video variations per scene (default: 1).
-
-Higher values provide more options but increase cost and generation time.
-
-#### `--timeout INTEGER`
-Video generation timeout in seconds (default: 600).
-
-Increase for busy provider queues or complex generations.
-
-### Advanced Options
-
-#### `--seed-assets, -s PATH`
-Directory containing seed images/assets (PNG/JPG).
-
-Provides reference images for video generation, improving consistency and relevance.
-
-#### `--execution-strategy, -e CHOICE`
-Scene execution strategy for continuity.
-
-**Choices:**
-- `auto` - Automatically detect from script (default)
-- `all_parallel` - Generate all scenes in parallel (fastest)
-- `all_sequential` - Generate scenes sequentially (best continuity)
-- `manual` - Use manual groups from script
-
-#### `--style CHOICE`
-Narrative style.
-
-**Choices:**
-- `visual_storyboard` - Visual-focused narrative (default)
-- `podcast` - Rich NotebookLM-style narration
-- `educational` - Educational lecture format
-- `documentary` - Documentary style
-
-#### `--mode CHOICE`
-Production mode.
-
-**Choices:**
-- `video-led` - Video determines timing (default)
-- `audio-led` - Audio determines timing
-
-### Output Options
-
-#### `--output-dir, -o PATH`
-Output directory.
-
-**Default:** `artifacts/runs/<run_id>`
-
-#### `--run-id TEXT`
-Custom run ID.
-
-**Default:** Auto-generated timestamp (`YYYYMMDD_HHMMSS`)
-
-### Display Options
-
-#### `--verbose, -V`
-Show full artifacts without truncation.
-
-Displays complete scene descriptions, prompts, and evaluation details.
-
-#### `--theme, -t TEXT`
-Color theme.
-
-**Choices:** `default`, `ocean`, `sunset`, `matrix`, `pro`, `neon`, `mono`
-
-#### `--json`
-Output results as JSON.
-
-Suppresses rich formatting and returns structured data.
-
-#### `--debug`
-Enable debug output.
-
-Shows detailed error traces and internal processing information.
-
-## Examples
-
-### Basic Usage
+## Quick Start
 
 ```bash
-# Quick 5-second demo with mock providers
-claude-studio produce -c "Logo reveal for TechCorp" -d 5 --mock
+# Research a topic end-to-end (mock, no cost)
+cs produce topic "How to make French press coffee" --mock
 
-# Live production with Luma (costs money)
-claude-studio produce -c "Product demo for mobile app" -b 15 -d 30 --live -p luma
+# Produce from a knowledge base you've already built
+cs produce paper kb_1c28d10264bd --live -p luma
 
-# Full production with audio
-claude-studio produce -c "Tutorial video" -b 50 -d 60 --audio-tier simple_overlay --live
+# Produce from a script file with a budget cap
+cs produce script myscript.txt --budget 15 --live
+
+# Check on / resume a run
+cs produce status 20260617_101500
+cs produce resume 20260617_101500
 ```
 
-### Advanced Usage
+## Common Production Options
+
+`paper`, `topic`, `script`, and `project` share a common set of production options:
+
+| Option | Description |
+|--------|-------------|
+| `-p, --provider TEXT` | Preferred video provider: `luma`, `higgsfield`, or `auto` |
+| `--interactive / --no-interactive` | Interactive pre-production (figure selection) |
+| `--live / --mock` | Use real API providers vs. a dry run (mock) |
+| `-d, --duration FLOAT` | Target duration in seconds |
+| `--voice TEXT` | TTS voice |
+| `-l, --language TEXT` | Script/TTS language (ISO 639-1: `en`, `cs`, `es`, `fr`, `de`, `ja`, …) |
+| `-s, --style TEXT` | Video style: `explainer`, `documentary`, `tutorial` |
+| `-b, --budget FLOAT` | Total budget in USD |
+
+> Note: `--provider` choices (`luma`, `higgsfield`, `auto`) and `--style`
+> values (`explainer`, `documentary`, `tutorial`) differ from the
+> [`produce-legacy`](produce-legacy.md) command's older option set.
+
+---
+
+## produce paper
+
+Produce a video from a knowledge base project.
 
 ```bash
-# Use seed images for consistent branding
-claude-studio produce -c "Product showcase" --live -s ./brand_assets/
-
-# Generate multiple variations
-claude-studio produce -c "Marketing video" -b 30 -v 3 --live
-
-# Extended timeout for complex scenes
-claude-studio produce -c "Complex animation" --live --timeout 900
-
-# Podcast-style narration
-claude-studio produce -c "Explain quantum computing" --style podcast --audio-tier time_synced
-
-# Audio-led production (audio timing drives video)
-claude-studio produce -c "Music video concept" --mode audio-led --audio-tier time_synced
+cs produce paper KB_ID [OPTIONS]
 ```
 
-### Output Control
+- **`KB_ID`** — the project name or ID (e.g. `kb_1c28d10264bd`). Build one first with [`kb`](kb.md) / [`document`](document.md).
+- **`-c, --prompt TEXT`** — production direction/focus (here `-c` is the *prompt*, not a concept).
+- Plus the [common production options](#common-production-options).
 
 ```bash
-# Custom output directory
-claude-studio produce -c "test" --mock -o ./my_production/
-
-# Custom run ID
-claude-studio produce -c "test" --mock --run-id my_custom_run
-
-# JSON output for scripting
-claude-studio produce -c "test" --mock --json > result.json
-
-# Different color theme
-claude-studio produce -c "test" --mock --theme matrix
-
-# Verbose output with full details
-claude-studio produce -c "test" --mock --verbose
+cs produce paper kb_1c28d10264bd --mock
+cs produce paper kb_1c28d10264bd -c "focus on the methods section" --live -p luma -d 90
 ```
+
+## produce topic
+
+Research a topic and produce a video. Automatically researches the topic, builds a KB, then produces.
+
+```bash
+cs produce topic TOPIC_TEXT [OPTIONS]
+```
+
+- **`TOPIC_TEXT`** — the topic to research (positional).
+- Plus the [common production options](#common-production-options).
+
+```bash
+cs produce topic "How to make French press coffee" --mock
+cs produce topic "The history of jazz" --live -d 120 -s documentary
+```
+
+## produce script
+
+Produce a video from a pre-written script file.
+
+```bash
+cs produce script SCRIPT_FILE [OPTIONS]
+```
+
+- **`SCRIPT_FILE`** — path to the script.
+- Plus the [common production options](#common-production-options).
+
+```bash
+cs produce script myscript.txt --mock
+cs produce script myscript.txt --budget 15 --live --voice nova
+```
+
+## produce project
+
+Multi-source production from shards + KB + assets. Combines knowledge from multiple sources into a single video. **Interactive mode is the default** for project builds.
+
+```bash
+cs produce project -c PROMPT [OPTIONS]
+```
+
+- **`-c, --prompt TEXT`** — production prompt (**required**).
+- **`--shards TEXT`** — shard refs to hydrate.
+- **`--kb TEXT`** — KB project IDs to include.
+- **`--assets TEXT`** — asset files/dirs to include.
+- Plus the [common production options](#common-production-options).
+
+```bash
+cs produce project -c "Quarterly research roundup" \
+  --kb kb_1c28d10264bd --kb kb_99fe... \
+  --assets ./brand_assets/ --live
+```
+
+## produce status
+
+Show the status of a production run.
+
+```bash
+cs produce status RUN_ID
+```
+
+## produce resume
+
+Resume a production run from its last checkpoint.
+
+```bash
+cs produce resume RUN_ID [--from {plan|production|audio|assembly}]
+```
+
+- **`--from`** — optionally resume from a specific stage rather than the last checkpoint.
+
+```bash
+cs produce resume 20260617_101500
+cs produce resume 20260617_101500 --from audio
+```
+
+## produce list
+
+List all production runs.
+
+```bash
+cs produce list
+```
+
+## produce edit
+
+Edit a specific scene in a production run — swap providers, replace assets, or redo individual scenes without affecting the rest of the production.
+
+```bash
+cs produce edit RUN_ID [OPTIONS]
+```
+
+- **`--scene TEXT`** — scene ID to edit.
+- **`-p, --provider TEXT`** — new provider for the scene.
+- **`--asset PATH`** — replace the scene's asset.
+
+```bash
+cs produce edit 20260617_101500 --scene scene_003 -p higgsfield
+cs produce edit 20260617_101500 --scene scene_003 --asset ./new_clip.mp4
+```
+
+---
 
 ## Pipeline Stages
 
-### Stage 1: Planning (Sequential)
-
-1. **ProducerAgent** analyzes concept and creates pilot strategies
-   - Budget allocation across production tiers
-   - Provider knowledge from long-term memory
-   - Risk assessment and feasibility analysis
-
-2. **ScriptWriterAgent** generates scene breakdown
-   - Optimal scene count based on duration
-   - Visual elements and transitions
-   - Prompt optimization for selected provider
-
-**Output:** Scene specifications and production plan
-
-### Stage 2: Asset Generation (Parallel via Strands)
-
-1. **VideoGeneratorAgent** creates video content
-   - Uses execution strategy for continuity
-   - Parallel or sequential generation based on dependencies
-   - Seed asset integration when provided
-
-2. **AudioGeneratorAgent** generates voiceover and music (if enabled)
-   - Text-to-speech with selected voice
-   - Background music matching video tone
-   - Timing synchronization with video duration
-
-**Output:** Video clips and audio tracks
-
-### Stage 3: Evaluation (Sequential)
-
-1. **QAVerifierAgent** analyzes video quality
-   - Visual accuracy and coherence
-   - Style consistency across scenes
-   - Technical quality assessment
-   - Narrative fit with original concept
-
-2. **CriticAgent** scores production quality
-   - Overall production evaluation
-   - Budget efficiency analysis
-   - Approval/rejection recommendation
-   - Provider performance learning
-
-3. **EditorAgent** creates Edit Decision Lists (EDLs)
-   - Multiple edit candidate generation
-   - Transition selection and timing
-   - Text overlay positioning
-   - Final assembly instructions
-
-**Output:** Quality scores, approval status, and EDL
-
-### Stage 4: Rendering
-
-1. **AudioMixer** combines video and audio
-   - Fit mode based on production mode
-   - Volume balancing and normalization
-   - Scene concatenation
-
-2. **FFmpegRenderer** creates final video
-   - Transition effects application
-   - Text overlay rendering
-   - Format optimization
-
-**Output:** Final rendered video
-
-## Output Structure
-
-Production runs create organized directory structures:
-
-```
-artifacts/runs/<run_id>/
-├── metadata.json           # Run metadata and costs
-├── scenes/                 # Scene specifications
-│   ├── scene_001.json
-│   ├── scene_002.json
-│   └── ...
-├── videos/                 # Generated video clips
-│   ├── scene_001_v0.mp4
-│   ├── scene_002_v0.mp4
-│   └── ...
-├── audio/                  # Audio files (if enabled)
-│   ├── scene_001_voice.mp3
-│   └── background_music.mp3
-├── edl/                    # Edit Decision Lists
-│   ├── edit_candidates.json
-│   ├── recommended_cut.json
-│   └── ...
-├── renders/                # Final rendered videos
-│   └── final_video.mp4
-├── mixed/                  # Video+audio combinations
-│   └── scene_001_mixed.mp4
-└── final_output.mp4        # Complete final video
-```
-
-## Budget and Cost Management
-
-The produce command includes sophisticated budget management:
-
-### Production Tiers
-
-Based on budget allocation:
-
-- **Micro** ($0-5): Single scenes, basic quality
-- **Low** ($5-15): Multiple scenes, standard quality
-- **Medium** ($15-50): Enhanced quality, multiple variations
-- **High** ($50-100): Premium quality, extensive variations
-- **Full** ($100+): Maximum quality, comprehensive production
-
-### Cost Tracking
-
-Costs are tracked throughout production:
-
-```json
-{
-  "costs": {
-    "video": 2.50,
-    "audio": 0.15,
-    "total": 2.65
-  },
-  "budget_allocated": 10.00,
-  "budget_spent": 2.65
-}
-```
-
-## Memory and Learning
-
-The produce command leverages long-term memory for optimization:
-
-### Provider Learning
-- Successful prompt patterns
-- Quality score trends  
-- Cost optimization strategies
-- Common failure modes
-
-### Pattern Recognition
-- Scene types that work well
-- Optimal duration ranges
-- Effective transitions
-- Audio-video synchronization
-
-## Error Handling
-
-Common issues and solutions:
-
-### API Configuration
-```bash
-# Missing API keys
-Error: LUMA_API_KEY not set (check keychain or env)
-
-# Solution
-claude-studio secrets set LUMA_API_KEY your_key
-```
-
-### Budget Constraints
-```bash
-# Insufficient budget
-Warning: Concept complexity requires $15+ budget, got $5
-
-# Solution
-claude-studio produce -c "concept" -b 20 --live
-```
-
-### Generation Failures
-```bash
-# Provider timeout
-Error: Video generation timeout after 600s
-
-# Solution  
-claude-studio produce -c "concept" --timeout 900 --live
-```
-
-### FFmpeg Issues
-```bash
-# Missing FFmpeg
-Warning: FFmpeg not installed - skipping render
-
-# Solution
-brew install ffmpeg  # macOS
-sudo apt install ffmpeg  # Ubuntu
-```
+All `produce` subcommands feed the same multi-agent pipeline. For the full stage-by-stage breakdown (Planning → Asset Generation → Evaluation → Rendering), production tiers, output directory structure, and cost tracking, see [produce-legacy.md](produce-legacy.md#pipeline-stages) — the engine is shared.
 
 ## Integration with Other Commands
 
-### Resume Failed Productions
 ```bash
-# If production fails, resume from checkpoint
-claude-studio resume <run_id> --live
+# Build the knowledge base first
+cs kb create "Coffee Research"
+cs kb add coffee-research --paper brewing.pdf
+cs produce paper coffee-research --live
+
+# After a run: inspect, assemble, render, upload
+cs produce status <run_id>
+cs figures list artifacts/runs/<run_id>
+cs assemble <run_id>
+cs upload youtube artifacts/runs/<run_id>/final_output.mp4 -t "My Video"
 ```
 
-### Re-render with Different Settings
-```bash
-# Use existing assets with new edit
-claude-studio render edl <run_id> -c creative_cut
-```
+## See Also
 
-### Upload Results
-```bash
-# Upload final video to YouTube
-claude-studio upload youtube artifacts/runs/<run_id>/final_output.mp4 \
-  -t "My Video Title"
-```
-
-### Asset Management
-```bash
-# Review and approve individual assets
-claude-studio assets list artifacts/runs/<run_id>
-claude-studio assets approve artifacts/runs/<run_id> --image all
-```
-
-## Performance Tips
-
-### Development
-- Use `--mock` flag during development
-- Start with short durations (5-10s)
-- Test concepts with single variations
-
-### Production
-- Set appropriate timeouts for complex scenes
-- Use seed assets for consistency
-- Monitor costs with budget limits
-- Utilize multiple variations for better results
-
-### Optimization
-- Reuse approved assets across runs
-- Leverage provider learning from memory
-- Batch similar productions for efficiency
-
-## Version History
-
-- **0.6.0**: Current version with unified production architecture
-- **0.5.x**: Multi-agent orchestration with Strands patterns  
-- **0.4.x**: Basic video generation pipeline
+- [produce-legacy.md](produce-legacy.md) — the classic one-shot `produce-legacy -c "concept"` pipeline, with the detailed stage/budget/output reference.
+- [kb.md](kb.md), [document.md](document.md) — build the knowledge bases that `produce paper` / `produce project` consume.
+- [resume.md](resume.md), [assemble.md](assemble.md), [render.md](render.md), [upload.md](upload.md) — post-production.

--- a/docs/cli/render.md
+++ b/docs/cli/render.md
@@ -563,7 +563,7 @@ ffmpeg -i source.mp4 -crf 30 -s 1280x720 mobile_quality.mp4
 # Complete video production and rendering pipeline
 
 # 1. Generate video
-claude-studio produce -c "Product demonstration" -b 25 -d 45 --live -p luma
+claude-studio produce-legacy -c "Product demonstration" -b 25 -d 45 --live -p luma
 
 # 2. Resume if needed
 claude-studio resume latest --live

--- a/docs/cli/resume.md
+++ b/docs/cli/resume.md
@@ -359,7 +359,7 @@ Resume fits into the complete production workflow:
 
 ```bash
 # 1. Start production
-claude-studio produce -c "Product demo" -b 20 --live -p luma
+claude-studio produce-legacy -c "Product demo" -b 20 --live -p luma
 
 # 2. Production interrupted (API limit, network, etc.)
 # ... interruption occurs ...

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -128,7 +128,7 @@ The most powerful workflow: generate video, audio, and automatically mix them in
 
 ```bash
 # Audio-led production where narration drives the timeline
-claude-studio produce "The history of espresso" --style podcast --budget 10 --live --provider luma
+claude-studio produce-legacy -c "The history of espresso" --style podcast --budget 10 --live --provider luma
 
 # What happens automatically:
 # 1. ScriptWriter breaks down the concept into scenes
@@ -177,7 +177,7 @@ The system supports two production workflows:
 
 **Audio-Led (Explicit):**
 ```bash
-claude-studio produce "Coffee brewing techniques" \
+claude-studio produce-legacy -c "Coffee brewing techniques" \
   --mode audio-led \
   --budget 15 \
   --live \
@@ -187,7 +187,7 @@ claude-studio produce "Coffee brewing techniques" \
 
 **Video-Led (Default):**
 ```bash
-claude-studio produce "Cinematic product showcase" \
+claude-studio produce-legacy -c "Cinematic product showcase" \
   --style visual_storyboard \
   --budget 10 \
   --live \

--- a/docs/index.md
+++ b/docs/index.md
@@ -97,15 +97,16 @@ To a production-ready platform with:
 ## Quick Commands
 
 ```bash
-# Production (mock mode - no API costs)
-claude-studio produce "concept" --budget 5
+# Production — `produce` is a command group (pick an input subcommand)
+claude-studio produce topic "concept" --budget 5            # mock mode, no API costs
+claude-studio produce paper <kb_id> --budget 10 --live      # from a knowledge base
 
-# Live mode with automatic audio-video mixing
-claude-studio produce "concept" --style podcast --budget 10 --live
+# Classic one-shot concept->video (now `produce-legacy`)
+claude-studio produce-legacy -c "concept" --style podcast --budget 10 --live
 
-# Video-led vs audio-led production
-claude-studio produce "concept" --mode audio-led --budget 5 --live
-claude-studio produce "concept" --mode video-led --budget 5 --live
+# Video-led vs audio-led production (legacy)
+claude-studio produce-legacy -c "concept" --mode audio-led --budget 5 --live
+claude-studio produce-legacy -c "concept" --mode video-led --budget 5 --live
 
 # Knowledge base workflow
 claude-studio kb create "Research" -d "AI papers"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "claude-studio-producer"
-version = "0.7.0"
+dynamic = ["version"]
 description = "Budget-aware multi-agent video production orchestration using Claude Agent SDK"
 readme = "README.md"
 requires-python = ">=3.9"
@@ -88,6 +88,9 @@ cs = "cli:main"
 
 [tool.setuptools]
 packages = ["core", "agents", "cli", "server"]
+
+[tool.setuptools.dynamic]
+version = {attr = "cli._version.__version__"}
 
 [tool.setuptools.package-data]
 "*" = ["*.md"]

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -46,9 +46,11 @@ class TestMainGroup:
         assert "training" in result.output
 
     def test_version(self, runner):
+        from cli._version import __version__
+
         result = runner.invoke(main, ["--version"])
         assert result.exit_code == 0
-        assert "0.7.0" in result.output
+        assert __version__ in result.output
 
     def test_no_command_shows_help(self, runner):
         result = runner.invoke(main, [])
@@ -864,3 +866,65 @@ class TestSecretsCommand:
     def test_help(self, runner):
         result = runner.invoke(main, ["secrets", "--help"])
         assert result.exit_code == 0
+
+
+# ============================================================
+# Full command-tree coverage
+# ============================================================
+
+def _all_command_paths(cmd, prefix=()):
+    """Every (sub)command path under the root group, as token tuples."""
+    paths = []
+    for name, sub in getattr(cmd, "commands", {}).items():
+        path = prefix + (name,)
+        paths.append(path)
+        paths.extend(_all_command_paths(sub, path))
+    return paths
+
+
+ALL_COMMAND_PATHS = _all_command_paths(main)
+
+
+class TestEveryCommandHelp:
+    """Command-level coverage guarantee: every registered command and
+    subcommand must expose a working ``--help``.
+
+    Parametrized over the *live* Click tree, so commands added later are
+    covered automatically, and any command whose import/decorator wiring
+    breaks (or whose options fail to construct) fails here rather than only
+    surfacing at runtime for a user.
+    """
+
+    def test_command_tree_is_populated(self):
+        # Guard against the walker silently returning an empty/partial tree,
+        # which would make the parametrized test vacuously pass.
+        assert len(ALL_COMMAND_PATHS) >= 90
+
+    @pytest.mark.parametrize(
+        "path", ALL_COMMAND_PATHS, ids=[" ".join(p) for p in ALL_COMMAND_PATHS]
+    )
+    def test_help_works(self, runner, path):
+        result = runner.invoke(main, [*path, "--help"])
+        assert result.exit_code == 0, result.output
+        assert result.exception is None
+
+
+class TestProduceSubcommandSmoke:
+    """Functional smoke for the new ``produce`` verb-group (the surface this
+    branch introduces) beyond ``--help`` — the read-only/no-setup subcommands
+    run end-to-end against an empty workspace without raising."""
+
+    def test_list_runs_empty(self, isolated_runner):
+        result = isolated_runner.invoke(main, ["produce", "list"])
+        assert result.exit_code == 0
+        assert result.exception is None
+
+    def test_status_missing_run_is_graceful(self, isolated_runner):
+        result = isolated_runner.invoke(main, ["produce", "status", "nonexistent_run_id"])
+        assert result.exit_code == 0
+        assert result.exception is None
+
+    def test_resume_missing_run_is_graceful(self, isolated_runner):
+        result = isolated_runner.invoke(main, ["produce", "resume", "nonexistent_run_id"])
+        assert result.exit_code == 0
+        assert result.exception is None

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -897,8 +897,23 @@ class TestEveryCommandHelp:
 
     def test_command_tree_is_populated(self):
         # Guard against the walker silently returning an empty/partial tree,
-        # which would make the parametrized test vacuously pass.
-        assert len(ALL_COMMAND_PATHS) >= 90
+        # which would make the parametrized test vacuously pass. Rather than a
+        # loose count floor, assert a representative slice across the tree — a
+        # top-level command, the produce group + a subcommand, a nested group
+        # subcommand, and a leaf — so dropping a whole group fails here.
+        flat = {" ".join(p) for p in ALL_COMMAND_PATHS}
+        expected = {
+            "produce",            # the verb-group root
+            "produce paper",      # a produce subcommand
+            "produce-legacy",     # the renamed one-shot command
+            "kb",                 # a group
+            "kb produce",         # a nested subcommand
+            "upload youtube",     # a deeper nested subcommand
+            "secrets",            # another group
+            "status",             # a leaf command
+        }
+        missing = expected - flat
+        assert not missing, f"command tree missing expected commands: {sorted(missing)}"
 
     @pytest.mark.parametrize(
         "path", ALL_COMMAND_PATHS, ids=[" ".join(p) for p in ALL_COMMAND_PATHS]


### PR DESCRIPTION
## Post-consolidation housekeeping: v0.8.0 + CLI docs refresh + command coverage

Follow-up to the KB-pipeline consolidation (#15, PRs #16–#22). Three related pieces of cleanup that were outstanding after the migration: the version was never bumped, the CLI docs went stale around the `produce` restructure, and CLI command coverage had big gaps.

### Version → 0.8.0 (drift-proof)
- New single source `cli/_version.py`; `pyproject.toml` derives the version via `[tool.setuptools.dynamic]`, and the CLI imports it for `--version`.
- Fixes a real drift: `--version` was hardcoded `0.7.0` separately from `pyproject`, and `importlib.metadata` read a stale `0.6.0` in editable installs. Verified both runtime (`0.8.0`) and build-time static resolution (`0.8.0`) — no reinstall needed.
- `CHANGELOG` `[Unreleased]` → `[0.8.0]`, documenting the full consolidation (#16–#22, #21), the `claude-sonnet-4-6` default change, and this docs refresh.

### CLI docs refresh (the `produce` restructure)
`produce` is now a **command group** — `paper` / `topic` / `script` / `project` / `status` / `resume` / `list` / `edit` — and the old one-shot `produce -c CONCEPT` is now **`produce-legacy`**. The docs still described the old flow everywhere.

- Rewrote `docs/cli/produce.md` as the verb-group reference (each subcommand + its real options).
- Added `docs/cli/produce-legacy.md` preserving the detailed pipeline/budget/output reference (the engine is unchanged, just renamed).
- Corrected the in-code `--help` docstring, `produce-legacy`'s own docstring, `docs/cli/README.md`, `README.md`, `docs/index.md`, `docs/examples.md`, `CLAUDE.md`, the `/produce` slash command, and stray cross-refs in `render.md`/`resume.md`.
- Left as-is: `kb produce` (still valid), `examples/README.md` (separate `e2e_production.py` script), and `docs/specs/*` + historical logs (point-in-time design docs).

### CLI command coverage: 30/100 → 100/100
- New parametrized `TestEveryCommandHelp` walks the **live** Click tree and asserts every command's `--help` works — self-maintaining (new commands auto-covered) and catches broken command wiring before users hit it. A guard test fails if the tree walk returns a partial/empty set.
- Functional smokes for the new `produce list` / `status` / `resume` (graceful on an empty workspace).
- `test_version` now asserts against `cli._version` instead of a pinned literal.

### Validation
- `pytest tests/unit/test_cli.py` → **202 passed** (was 98).
- 100 parametrized help cases = one per registered command/subcommand.

### Noted for follow-up (not in this PR)
- **Line coverage of command bodies is ~25%** — `--help` proves wiring/parsing, not execution. Deeper functional tests (esp. the `produce` group / `produce_unified.py`) are a good dedicated follow-up.
- **`cli/combine.py` is 0% covered and not registered** in the command tree — possible dead code, worth a separate look.
