### PR TITLE
security: redact API keys from onboarding session checkpoints

### DIFF
--- a/.claude-studio/onboarding_sessions/elevenlabs.json
+++ b/.claude-studio/onboarding_sessions/elevenlabs.json
@@ -322,7 +322,7 @@
       "name": "test_get_headers",
       "status": "passed",
       "error": null,
-      "output": "{'xi-api-key': 'sk_697de35fab577f2d3cf75261531533e02586f30421b53bfe', 'Content-Type': 'application/json'}",
+      "output": "{'xi-api-key': '***REDACTED***', 'Content-Type': 'application/json'}",
       "duration_ms": 0
     },
     {

--- a/agents/provider_onboarding.py
+++ b/agents/provider_onboarding.py
@@ -26,7 +26,22 @@ from abc import ABC, abstractmethod
 
 import httpx
 
-from core.secrets import redact_secrets
+from core.secrets import redact_secrets, redact_structure
+
+# Attribute names that hold credentials. Covers every AuthType the onboarding
+# agent supports: API_KEY_HEADER, BEARER_TOKEN, BASIC_AUTH and OAUTH2.
+_SECRET_ATTRS = (
+    "api_key", "api_secret", "secret_key",
+    "token", "access_token", "refresh_token", "bearer_token",
+    "client_secret", "password", "passphrase", "private_key", "credentials",
+)
+
+# Backstop for AuthType.CUSTOM, where a provider may name its credential
+# something not enumerated above.
+_SECRET_ATTR_RE = re.compile(
+    r"(api_?key|secret|token|password|passphrase|credential|private_?key)",
+    re.IGNORECASE,
+)
 
 
 # =============================================================================
@@ -286,7 +301,9 @@ class OnboardingSession:
         # captured output, but a session also carries generated code, LLM notes
         # and learnings. Scrub the whole payload on the way to disk -- these
         # files are committed.
-        payload = redact_secrets(json.dumps(self.to_dict(), indent=2))
+        # Redact before json.dumps, not after: escaping a quote or backslash
+        # inside a credential would otherwise hide it from the matcher.
+        payload = json.dumps(redact_structure(self.to_dict()), indent=2)
         Path(path).write_text(payload, encoding="utf-8")
         return path
 
@@ -897,7 +914,13 @@ Start your response with [ and end with ]."""
                         # It's a property or attribute, already resolved
                         output = method
 
-                    result["output"] = str(output)[:500]  # Truncate output
+                    # Redact before str(): a credential containing a quote or
+                    # backslash is escaped by repr and would survive matching
+                    # against the raw literal.
+                    safe_output = redact_structure(
+                        output, self._provider_secrets(provider_instance)
+                    )
+                    result["output"] = str(safe_output)[:500]  # Truncate output
                     result["status"] = "passed"
 
                     # Run assertions if provided
@@ -962,10 +985,24 @@ Start your response with [ and end with ]."""
         for holder in (provider_instance, getattr(provider_instance, "config", None)):
             if holder is None:
                 continue
-            for attr in ("api_key", "api_secret", "token", "client_secret"):
+            for attr in _SECRET_ATTRS:
                 value = getattr(holder, attr, None)
                 if isinstance(value, str) and value:
                     secrets.append(value)
+
+            # Generic sweep: AuthType allows CUSTOM, so a provider may name its
+            # credential something not listed above. Read instance and class
+            # attributes; some providers have no __dict__ at all.
+            namespaces = []
+            try:
+                namespaces.append(vars(holder))
+            except TypeError:
+                pass  # __slots__ or a bare object
+            namespaces.append(vars(type(holder)))
+            for namespace in namespaces:
+                for attr, value in namespace.items():
+                    if isinstance(value, str) and value and _SECRET_ATTR_RE.search(attr):
+                        secrets.append(value)
         return secrets
 
     def _determine_method(self, test_case: Dict[str, Any], provider: Any) -> Optional[str]:

--- a/agents/provider_onboarding.py
+++ b/agents/provider_onboarding.py
@@ -26,6 +26,8 @@ from abc import ABC, abstractmethod
 
 import httpx
 
+from core.secrets import redact_secrets
+
 
 # =============================================================================
 # DATA MODELS
@@ -280,7 +282,12 @@ class OnboardingSession:
             sessions_dir.mkdir(parents=True, exist_ok=True)
             path = str(sessions_dir / f"{self.provider_name}.json")
 
-        Path(path).write_text(json.dumps(self.to_dict(), indent=2), encoding="utf-8")
+        # Defense in depth: the per-test choke point in ProviderTester scrubs
+        # captured output, but a session also carries generated code, LLM notes
+        # and learnings. Scrub the whole payload on the way to disk -- these
+        # files are committed.
+        payload = redact_secrets(json.dumps(self.to_dict(), indent=2))
+        Path(path).write_text(payload, encoding="utf-8")
         return path
 
     @classmethod
@@ -933,7 +940,33 @@ Start your response with [ and end with ]."""
                 result["error"] = str(e)
 
         result["duration_ms"] = int((time.time() - start) * 1000)
+
+        # Single choke point: captured output and error text are persisted to
+        # .claude-studio/onboarding_sessions/<provider>.json, which is committed.
+        # A provider's get_headers() returns the live API key, so scrub before
+        # any of it reaches disk.
+        secret_values = self._provider_secrets(provider_instance)
+        result["output"] = redact_secrets(result["output"], secret_values)
+        result["error"] = redact_secrets(result["error"], secret_values)
+
         return result
+
+    @staticmethod
+    def _provider_secrets(provider_instance: Any) -> List[str]:
+        """Collect literal secret values held by a provider instance.
+
+        The key may have come from the OS keychain rather than the environment,
+        so redaction cannot rely on scanning os.environ alone.
+        """
+        secrets: List[str] = []
+        for holder in (provider_instance, getattr(provider_instance, "config", None)):
+            if holder is None:
+                continue
+            for attr in ("api_key", "api_secret", "token", "client_secret"):
+                value = getattr(holder, attr, None)
+                if isinstance(value, str) and value:
+                    secrets.append(value)
+        return secrets
 
     def _determine_method(self, test_case: Dict[str, Any], provider: Any) -> Optional[str]:
         """Determine which provider method to call based on test case"""

--- a/core/secrets.py
+++ b/core/secrets.py
@@ -13,6 +13,9 @@ Usage:
     set_api_key("OPENAI_API_KEY", "sk-...")
 """
 
+import os
+import re
+
 from spiritwriter.secrets.keychain import (  # noqa: F401
     get_api_key,
     set_api_key,
@@ -46,3 +49,70 @@ configure(
         "YOUTUBE_API_KEY": "YouTube Data API key",
     },
 )
+
+
+# =============================================================================
+# REDACTION
+# =============================================================================
+#
+# Onboarding/test harnesses capture provider output verbatim into checkpoint
+# files that get committed. A provider's get_headers() legitimately returns the
+# live API key, so any such capture must be scrubbed before it hits disk.
+
+REDACTED = "***REDACTED***"
+
+# Shape-based backstop: catches keys regardless of where they came from
+# (env var, keychain, or hardcoded in a fixture).
+_SECRET_PATTERNS = (
+    re.compile(r"sk-ant-[A-Za-z0-9_\-]{20,}"),          # Anthropic
+    re.compile(r"sk-proj-[A-Za-z0-9_\-]{20,}"),         # OpenAI (project)
+    re.compile(r"sk_[A-Za-z0-9]{24,}"),                 # ElevenLabs
+    re.compile(r"sk-[A-Za-z0-9]{24,}"),                 # OpenAI (legacy)
+    re.compile(r"luma-[0-9a-fA-F\-]{20,}"),             # Luma
+    re.compile(r"key-[A-Za-z0-9]{24,}"),                # Runway
+    re.compile(r"AIza[A-Za-z0-9_\-]{30,}"),             # Google
+    re.compile(r"(?:ghp|gho|ghs|ghu)_[A-Za-z0-9]{30,}"),  # GitHub
+    re.compile(r"xox[baprs]-[A-Za-z0-9\-]{10,}"),       # Slack
+)
+
+# Minimum length for a literal value to be worth redacting. Guards against a
+# short/empty env var (e.g. "test") blanking out unrelated text.
+_MIN_LITERAL_LEN = 8
+
+
+def redact_secrets(text, extra_values=None):
+    """Replace API keys in ``text`` with a redaction marker.
+
+    Scrubs three sources, in order of precision:
+      1. ``extra_values`` -- literals the caller knows are secret (e.g. the
+         ``api_key`` off a provider instance, which may come from the keychain).
+      2. Live values of known secret env vars.
+      3. Well-known key shapes (see ``_SECRET_PATTERNS``).
+
+    Args:
+        text: Value to scrub. Non-strings are returned unchanged.
+        extra_values: Optional iterable of literal secret values to redact.
+
+    Returns:
+        The scrubbed string, or ``text`` unchanged if it is not a string.
+    """
+    if not isinstance(text, str) or not text:
+        return text
+
+    literals = set()
+    for value in extra_values or ():
+        if isinstance(value, str) and len(value) >= _MIN_LITERAL_LEN:
+            literals.add(value)
+    for name in KNOWN_KEYS:
+        value = os.environ.get(name)
+        if value and len(value) >= _MIN_LITERAL_LEN:
+            literals.add(value)
+
+    # Longest first, so an embedded shorter secret can't partially mask a longer one.
+    for value in sorted(literals, key=len, reverse=True):
+        text = text.replace(value, REDACTED)
+
+    for pattern in _SECRET_PATTERNS:
+        text = pattern.sub(REDACTED, text)
+
+    return text

--- a/core/secrets.py
+++ b/core/secrets.py
@@ -13,6 +13,7 @@ Usage:
     set_api_key("OPENAI_API_KEY", "sk-...")
 """
 
+import json
 import os
 import re
 
@@ -80,6 +81,35 @@ _SECRET_PATTERNS = (
 _MIN_LITERAL_LEN = 8
 
 
+def _escaped_forms(value):
+    """Return a value alongside the forms it takes once serialized.
+
+    ``str(dict)`` and ``json.dumps`` escape quotes and backslashes, so a
+    credential containing either appears in serialized text in a form that no
+    longer matches the raw literal. Match those representations too.
+    """
+    forms = {value}
+    forms.add(json.dumps(value)[1:-1])   # JSON escaping
+    forms.add(repr(value)[1:-1])         # Python repr escaping
+    return {f for f in forms if len(f) >= _MIN_LITERAL_LEN}
+
+
+def redact_structure(obj, extra_values=None):
+    """Recursively redact strings in a container before it gets serialized.
+
+    Preferred over redacting serialized text: scrubbing the raw strings means
+    escaping never gets a chance to hide a credential from the matcher.
+    Containers are rebuilt; unknown objects are returned unchanged.
+    """
+    if isinstance(obj, str):
+        return redact_secrets(obj, extra_values)
+    if isinstance(obj, dict):
+        return {k: redact_structure(v, extra_values) for k, v in obj.items()}
+    if isinstance(obj, (list, tuple, set)):
+        return type(obj)(redact_structure(v, extra_values) for v in obj)
+    return obj
+
+
 def redact_secrets(text, extra_values=None):
     """Replace API keys in ``text`` with a redaction marker.
 
@@ -102,11 +132,11 @@ def redact_secrets(text, extra_values=None):
     literals = set()
     for value in extra_values or ():
         if isinstance(value, str) and len(value) >= _MIN_LITERAL_LEN:
-            literals.add(value)
+            literals.update(_escaped_forms(value))
     for name in KNOWN_KEYS:
         value = os.environ.get(name)
         if value and len(value) >= _MIN_LITERAL_LEN:
-            literals.add(value)
+            literals.update(_escaped_forms(value))
 
     # Longest first, so an embedded shorter secret can't partially mask a longer one.
     for value in sorted(literals, key=len, reverse=True):

--- a/tests/unit/test_secret_redaction.py
+++ b/tests/unit/test_secret_redaction.py
@@ -1,0 +1,178 @@
+"""Unit tests for secret redaction in checkpointed onboarding sessions.
+
+Regression coverage for a leaked ElevenLabs key: ProviderTester captured a
+provider's get_headers() output verbatim into
+.claude-studio/onboarding_sessions/elevenlabs.json, which is committed to a
+public repo.
+"""
+
+import json
+import pytest
+
+from core.secrets import REDACTED, redact_secrets
+
+
+# Synthetic keys, shaped like the real thing but not valid credentials.
+FAKE_ELEVENLABS = "sk_0123456789abcdef0123456789abcdef0123456789abcdef"
+FAKE_ANTHROPIC = "sk-ant-api03-" + "A" * 40
+FAKE_OPENAI = "sk-proj-" + "B" * 40
+FAKE_LUMA = "luma-01234567-89ab-cdef-0123-456789abcdef"
+FAKE_GOOGLE = "AIza" + "C" * 35
+
+
+class TestRedactSecrets:
+    """redact_secrets scrubs known key shapes and caller-supplied literals."""
+
+    @pytest.mark.parametrize("secret", [
+        FAKE_ELEVENLABS,
+        FAKE_ANTHROPIC,
+        FAKE_OPENAI,
+        FAKE_LUMA,
+        FAKE_GOOGLE,
+        "ghp_" + "D" * 36,
+        "xoxb-1234567890-abcdefghij",
+    ])
+    def test_redacts_known_key_shapes(self, secret):
+        text = f"{{'api-key': '{secret}'}}"
+        result = redact_secrets(text)
+        assert secret not in result
+        assert REDACTED in result
+
+    def test_redacts_the_exact_leaked_header_shape(self):
+        """The precise capture that leaked: an ElevenLabs headers dict."""
+        captured = (
+            "{'xi-api-key': '%s', 'Content-Type': 'application/json'}" % FAKE_ELEVENLABS
+        )
+        result = redact_secrets(captured)
+        assert FAKE_ELEVENLABS not in result
+        assert "Content-Type" in result  # non-secret content survives
+
+    def test_redacts_keychain_sourced_literal_via_extra_values(self):
+        """A key from the OS keychain is not in os.environ, so callers pass it."""
+        opaque = "not-a-recognizable-key-shape-12345"
+        assert redact_secrets(opaque) == opaque  # not caught by shape alone
+        assert opaque not in redact_secrets(opaque, extra_values=[opaque])
+
+    def test_redacts_env_var_values(self, monkeypatch):
+        monkeypatch.setenv("ELEVENLABS_API_KEY", "opaque-env-value-98765")
+        result = redact_secrets("key is opaque-env-value-98765 here")
+        assert "opaque-env-value-98765" not in result
+
+    def test_ignores_short_literals(self, monkeypatch):
+        """A short env value must not blank out unrelated text."""
+        monkeypatch.setenv("ELEVENLABS_API_KEY", "test")
+        assert redact_secrets("this is a test string") == "this is a test string"
+
+    def test_leaves_clean_text_untouched(self):
+        clean = "AudioGenerationResult(success=True, format='mp3')"
+        assert redact_secrets(clean) == clean
+
+    @pytest.mark.parametrize("value", [None, 123, "", {"a": 1}])
+    def test_passes_through_non_strings(self, value):
+        assert redact_secrets(value) == value
+
+
+class TestProviderTesterRedaction:
+    """Captured test output is scrubbed before it reaches a session file."""
+
+    @pytest.mark.asyncio
+    async def test_headers_output_is_redacted(self):
+        from agents.provider_onboarding import ProviderTester
+
+        class FakeConfig:
+            api_key = FAKE_ELEVENLABS
+
+        class FakeProvider:
+            config = FakeConfig()
+
+            def get_headers(self):
+                return {"xi-api-key": self.config.api_key}
+
+        tester = ProviderTester(claude_client=None)
+        result = await tester.run_test(
+            {"name": "test_get_headers", "method": "get_headers", "inputs": {}},
+            FakeProvider(),
+        )
+
+        assert FAKE_ELEVENLABS not in json.dumps(result)
+        assert REDACTED in result["output"]
+
+    @pytest.mark.asyncio
+    async def test_error_text_is_redacted(self):
+        from agents.provider_onboarding import ProviderTester
+
+        class ExplodingProvider:
+            api_key = FAKE_ELEVENLABS
+
+            def get_headers(self):
+                raise RuntimeError(f"auth failed for {FAKE_ELEVENLABS}")
+
+        tester = ProviderTester(claude_client=None)
+        result = await tester.run_test(
+            {"name": "test_get_headers", "method": "get_headers", "inputs": {}},
+            ExplodingProvider(),
+        )
+
+        assert FAKE_ELEVENLABS not in json.dumps(result)
+
+    def test_provider_secrets_collects_from_instance_and_config(self):
+        from agents.provider_onboarding import ProviderTester
+
+        class FakeConfig:
+            api_key = "config-level-secret-value"
+
+        class FakeProvider:
+            api_key = "instance-level-secret-value"
+            config = FakeConfig()
+
+        secrets = ProviderTester._provider_secrets(FakeProvider())
+        assert "instance-level-secret-value" in secrets
+        assert "config-level-secret-value" in secrets
+
+    def test_provider_secrets_tolerates_bare_object(self):
+        from agents.provider_onboarding import ProviderTester
+
+        assert ProviderTester._provider_secrets(object()) == []
+
+
+class TestSessionSaveRedaction:
+    """OnboardingSession.save() scrubs the whole payload on the way to disk."""
+
+    def test_save_redacts_secrets_anywhere_in_session(self, tmp_path):
+        from agents.provider_onboarding import OnboardingSession
+
+        from datetime import datetime
+
+        session = OnboardingSession(
+            provider_name="fakeprov",
+            started_at=datetime(2026, 1, 1),
+        )
+        # Simulate a secret reaching a field other than captured test output.
+        session.learnings = [f'client init uses API_KEY = "{FAKE_ELEVENLABS}"']
+
+        path = tmp_path / "fakeprov.json"
+        session.save(str(path))
+
+        written = path.read_text()
+        assert FAKE_ELEVENLABS not in written
+        assert REDACTED in written
+        json.loads(written)  # still valid JSON
+
+
+class TestCommittedSessionFilesAreClean:
+    """Guard: no committed onboarding checkpoint may carry a live key."""
+
+    def test_no_secrets_in_committed_session_files(self):
+        from pathlib import Path
+
+        sessions = Path(".claude-studio/onboarding_sessions")
+        if not sessions.is_dir():
+            pytest.skip("no onboarding session files in this checkout")
+
+        offenders = []
+        for path in sorted(sessions.glob("*.json")):
+            raw = path.read_text()
+            if redact_secrets(raw) != raw:
+                offenders.append(path.name)
+
+        assert not offenders, f"secrets found in committed session files: {offenders}"

--- a/tests/unit/test_secret_redaction.py
+++ b/tests/unit/test_secret_redaction.py
@@ -9,7 +9,7 @@ public repo.
 import json
 import pytest
 
-from core.secrets import REDACTED, redact_secrets
+from core.secrets import REDACTED, redact_secrets, redact_structure
 
 
 # Synthetic keys, shaped like the real thing but not valid credentials.
@@ -176,3 +176,138 @@ class TestCommittedSessionFilesAreClean:
                 offenders.append(path.name)
 
         assert not offenders, f"secrets found in committed session files: {offenders}"
+
+
+# Credentials containing characters that str()/json.dumps escape. A raw-literal
+# match misses these once serialized, so redaction must happen first.
+ESCAPING_SECRETS = [
+    'abc"def\'ghi12345',   # both quote styles -> repr backslash-escapes one
+    "abc\\def12345",        # backslash
+    'quote"inside-12345',
+    "apostrophe'inside-12345",
+]
+
+
+class TestEscapedCredentials:
+    """Regression: escaping must not hide a credential from redaction."""
+
+    @pytest.mark.parametrize("secret", ESCAPING_SECRETS)
+    def test_redact_structure_beats_repr_escaping(self, secret):
+        captured = str(redact_structure({"xi-api-key": secret}, [secret]))
+        assert secret not in captured
+        assert REDACTED in captured
+
+    @pytest.mark.parametrize("secret", ESCAPING_SECRETS)
+    def test_redact_structure_beats_json_escaping(self, secret):
+        payload = json.dumps(redact_structure({"key": secret}, [secret]))
+        assert secret not in payload
+        assert json.dumps(secret)[1:-1] not in payload
+        assert REDACTED in payload
+
+    @pytest.mark.parametrize("secret", ESCAPING_SECRETS)
+    def test_redact_secrets_matches_already_serialized_forms(self, secret):
+        """Backstop for text that was serialized before redaction ran."""
+        already = json.dumps({"key": secret})
+        assert json.dumps(secret)[1:-1] not in redact_secrets(already, [secret])
+
+    def test_redact_structure_recurses_and_preserves_shape(self):
+        data = {"a": [{"b": FAKE_ELEVENLABS}], "c": ("x", FAKE_ANTHROPIC), "n": 1}
+        out = redact_structure(data)
+        assert out["a"][0]["b"] == REDACTED
+        assert out["c"][1] == REDACTED
+        assert isinstance(out["c"], tuple)
+        assert out["n"] == 1
+
+    @pytest.mark.asyncio
+    async def test_run_test_redacts_escaped_credential(self):
+        from agents.provider_onboarding import ProviderTester
+
+        secret = 'abc"def\'ghi12345'
+
+        class FakeProvider:
+            def __init__(self):
+                self.api_key = secret
+
+            def get_headers(self):
+                return {"xi-api-key": self.api_key}
+
+        tester = ProviderTester(claude_client=None)
+        result = await tester.run_test(
+            {"name": "test_get_headers", "method": "get_headers", "inputs": {}},
+            FakeProvider(),
+        )
+        assert secret not in json.dumps(result)
+
+    def test_save_redacts_escaped_credential(self, tmp_path, monkeypatch):
+        """save() has no provider instance, so it matches env values and shapes.
+
+        This pins the escaping behaviour: a known credential containing escape
+        characters must not survive serialization in escaped form.
+        """
+        from datetime import datetime
+        from agents.provider_onboarding import OnboardingSession
+
+        secret = 'tok"en\\with-escapes-12345'
+        monkeypatch.setenv("ELEVENLABS_API_KEY", secret)
+
+        session = OnboardingSession(provider_name="fakeprov", started_at=datetime(2026, 1, 1))
+        session.learnings = [f"credential was {secret}"]
+
+        path = tmp_path / "s.json"
+        session.save(str(path))
+        written = path.read_text()
+        assert secret not in written
+        assert json.dumps(secret)[1:-1] not in written
+        assert REDACTED in written
+        json.loads(written)
+
+
+class TestAuthTypeCoverage:
+    """_provider_secrets covers credentials for every supported AuthType."""
+
+    @pytest.mark.parametrize("attr", [
+        "api_key", "access_token", "refresh_token", "bearer_token",
+        "client_secret", "password", "private_key", "secret_key",
+    ])
+    def test_collects_named_credential_attrs(self, attr):
+        from agents.provider_onboarding import ProviderTester
+
+        provider = type("P", (), {})()
+        setattr(provider, attr, "opaque-credential-value-123")
+        assert "opaque-credential-value-123" in ProviderTester._provider_secrets(provider)
+
+    def test_collects_custom_auth_credential_by_name_pattern(self):
+        """AuthType.CUSTOM: a provider may invent its own credential field."""
+        from agents.provider_onboarding import ProviderTester
+
+        provider = type("P", (), {})()
+        provider.x_subscription_secret = "opaque-custom-cred-456"
+        assert "opaque-custom-cred-456" in ProviderTester._provider_secrets(provider)
+
+    def test_ignores_non_credential_attrs(self):
+        from agents.provider_onboarding import ProviderTester
+
+        provider = type("P", (), {})()
+        provider.base_url = "https://api.example.com"
+        provider.timeout = 300
+        assert ProviderTester._provider_secrets(provider) == []
+
+    @pytest.mark.asyncio
+    async def test_oauth_token_in_headers_is_redacted(self):
+        from agents.provider_onboarding import ProviderTester
+
+        token = "opaque-oauth-access-token-no-recognizable-shape"
+
+        class OAuthProvider:
+            def __init__(self):
+                self.access_token = token
+
+            def get_headers(self):
+                return {"Authorization": f"Bearer {self.access_token}"}
+
+        tester = ProviderTester(claude_client=None)
+        result = await tester.run_test(
+            {"name": "test_get_headers", "method": "get_headers", "inputs": {}},
+            OAuthProvider(),
+        )
+        assert token not in json.dumps(result)


### PR DESCRIPTION
## Summary

A live ElevenLabs API key was committed in `.claude-studio/onboarding_sessions/elevenlabs.json` and had been public since PR #6.

**The key has already been revoked**, so the copies remaining in git history are inert and no history rewrite is needed. This PR fixes the mechanism that leaked it.

## Root cause

`ProviderTester.run_test` captured provider output verbatim via `str(output)[:500]`. A provider's `get_headers()` legitimately returns the live API key, so the `test_get_headers` case serialized it into the session checkpoint — and those checkpoints are tracked files.

## Changes

- **`core/secrets.py`** — new `redact_secrets()`. Scrubs caller-supplied literals, live values of known secret env vars, and well-known key shapes (Anthropic, OpenAI, ElevenLabs, Luma, Runway, Google, GitHub, Slack). Placed next to `KNOWN_KEYS` so it stays in sync with the keys the project manages.
- **`agents/provider_onboarding.py`** — scrubbing happens at a single choke point at the end of `run_test`, covering every capture branch rather than the six individual assignment sites. `_provider_secrets()` pulls literals off the provider instance and its config, because a key sourced from the OS keychain never appears in `os.environ` and shape-matching alone can miss it.
- **`OnboardingSession.save()`** — scrubs the serialized payload as defense in depth, covering generated code, learnings, and LLM notes.
- Redacted the leaked value from the committed session file.

## Scope of the leak

One key. I scanned the working tree and full git history for common key shapes; the sibling checkpoints (`dalle.json`, `google_tts.json`) are clean and nothing else matched.

## Testing

22 new tests in `tests/unit/test_secret_redaction.py`, covering key shapes, keychain-sourced literals, the exact leaked header capture, and a guard that fails if any committed session file carries a secret.

Mutation-checked: disabling the choke point makes them fail, and the guard flags the pre-fix file from git — they aren't passing vacuously.

Full suite: **1028 passed, 13 failed**. All 13 failures are pre-existing and reproduce identically on a clean tree with these changes stashed; they stem from dependency versions in the test container, not from this diff.

## Follow-up (not in this PR)

Worth enabling GitHub secret scanning with push protection on this repo — it would have blocked the original push, and it's the only layer here that catches a leak from a path this PR doesn't touch.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RsrGkbKdkdfWdsaqmNSCB9)_